### PR TITLE
feat(consult): Firebase Storage 연동 및 이미지 다중 업로드 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,10 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose.libs)
 
+    // Firestore
     implementation(platform(libs.firebase.bom))
     implementation(libs.bundles.firebase.libs)
+    implementation(libs.firebase.storage)
 
     // Splash
     implementation(libs.androidx.core.splashscreen)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     // Firestore
     implementation(platform(libs.firebase.bom))
     implementation(libs.bundles.firebase.libs)
+    implementation(libs.firebase.storage)
 
     // Map
     implementation(libs.bundles.google.maps.libs)

--- a/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
+++ b/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
@@ -39,3 +39,7 @@ const val USER_TYPE_PHARMACIST = "PHARMACIST"
 
 // 6. 에러 메시지 (Error Messages)
 const val ERROR_MSG_PHARMACY_NOT_FOUND = "Pharmacy not found"
+const val ERROR_MSG_UPLOAD_FAILED = "Upload failed"
+
+// 7. Firebase Storage 설정 (Storage)
+const val STORAGE_CONSULT_IMAGES = "consult_images"

--- a/data/src/main/java/com/moon/pharm/data/datasource/ImageDataSource.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/ImageDataSource.kt
@@ -1,0 +1,5 @@
+package com.moon.pharm.data.datasource
+
+interface ImageDataSource {
+    suspend fun uploadImage(uriString: String, userId: String): String
+}

--- a/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirebaseImageDataSourceImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirebaseImageDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.moon.pharm.data.datasource.remote.firebase
+
+import androidx.core.net.toUri
+import com.google.firebase.storage.FirebaseStorage
+import com.moon.pharm.data.common.ERROR_MSG_UPLOAD_FAILED
+import com.moon.pharm.data.common.STORAGE_CONSULT_IMAGES
+import com.moon.pharm.data.datasource.ImageDataSource
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class FirebaseImageDataSourceImpl @Inject constructor(
+    private val storage: FirebaseStorage
+) : ImageDataSource {
+
+    override suspend fun uploadImage(uriString: String, userId: String): String = suspendCancellableCoroutine { continuation ->
+        val fileName = "${System.currentTimeMillis()}_${uriString.substringAfterLast("/")}"
+        val ref = storage.reference.child("${STORAGE_CONSULT_IMAGES}/$userId/$fileName")
+        val uri = uriString.toUri()
+
+        ref.putFile(uri)
+            .continueWithTask { task ->
+                if (!task.isSuccessful) {
+                    task.exception?.let { throw it }
+                }
+                ref.downloadUrl
+            }
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    continuation.resume(task.result.toString())
+                } else {
+                    continuation.resumeWithException(task.exception ?: Exception(ERROR_MSG_UPLOAD_FAILED))
+                }
+            }
+    }
+}

--- a/data/src/main/java/com/moon/pharm/data/di/DataSourceModule.kt
+++ b/data/src/main/java/com/moon/pharm/data/di/DataSourceModule.kt
@@ -2,12 +2,14 @@ package com.moon.pharm.data.di
 
 import com.moon.pharm.data.datasource.AuthDataSource
 import com.moon.pharm.data.datasource.ConsultDataSource
+import com.moon.pharm.data.datasource.ImageDataSource
 import com.moon.pharm.data.datasource.MedicationDataSource
 import com.moon.pharm.data.datasource.PharmacistDataSource
-import com.moon.pharm.data.datasource.PharmacyStorageDataSource
 import com.moon.pharm.data.datasource.PharmacySearchDataSource
+import com.moon.pharm.data.datasource.PharmacyStorageDataSource
 import com.moon.pharm.data.datasource.UserDataSource
 import com.moon.pharm.data.datasource.remote.firebase.FirebaseAuthDataSourceImpl
+import com.moon.pharm.data.datasource.remote.firebase.FirebaseImageDataSourceImpl
 import com.moon.pharm.data.datasource.remote.firebase.FirestoreConsultDataSourceImpl
 import com.moon.pharm.data.datasource.remote.firebase.FirestoreMedicationDataSourceImpl
 import com.moon.pharm.data.datasource.remote.firebase.FirestorePharmacistDataSourceImpl
@@ -64,4 +66,10 @@ abstract class DataSourceModule {
     abstract fun bindMedicationDataSource(
         impl: FirestoreMedicationDataSourceImpl
     ): MedicationDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindImageDataSource(
+        impl: FirebaseImageDataSourceImpl
+    ): ImageDataSource
 }

--- a/data/src/main/java/com/moon/pharm/data/di/FirestoreModule.kt
+++ b/data/src/main/java/com/moon/pharm/data/di/FirestoreModule.kt
@@ -2,6 +2,7 @@ package com.moon.pharm.data.di
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,4 +22,10 @@ object FirestoreModule {
     @Provides
     @Singleton
     fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideFirebaseStorage(): FirebaseStorage {
+        return FirebaseStorage.getInstance()
+    }
 }

--- a/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.moon.pharm.data.repository
 
 import com.moon.pharm.data.datasource.ConsultDataSource
+import com.moon.pharm.data.datasource.ImageDataSource
 import com.moon.pharm.data.di.IoDispatcher
 import com.moon.pharm.domain.model.consult.ConsultError
 import com.moon.pharm.domain.model.consult.ConsultItem
@@ -17,6 +18,7 @@ import javax.inject.Inject
 
 class ConsultRepositoryImpl @Inject constructor(
     private val dataSource: ConsultDataSource,
+    private val imageDataSource: ImageDataSource,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ConsultRepository {
 
@@ -53,5 +55,9 @@ class ConsultRepositoryImpl @Inject constructor(
             .onStart { emit(DataResourceResult.Loading) }
             .catch { e -> emit(DataResourceResult.Failure(e)) }
             .flowOn(ioDispatcher)
+    }
+
+    override suspend fun uploadImage(uri: String, userId: String): String {
+        return imageDataSource.uploadImage(uri, userId)
     }
 }

--- a/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
@@ -8,4 +8,5 @@ interface ConsultRepository {
     fun createConsult(consultInfo: ConsultItem): Flow<DataResourceResult<Unit>>
     fun getConsultItems(): Flow<DataResourceResult<List<ConsultItem>>>
     fun getConsultDetail(id: String): Flow<DataResourceResult<ConsultItem>>
+    suspend fun uploadImage(uri: String, userId: String): String
 }

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/UploadConsultImagesUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/UploadConsultImagesUseCase.kt
@@ -1,0 +1,20 @@
+package com.moon.pharm.domain.usecase.consult
+
+import com.moon.pharm.domain.repository.ConsultRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import javax.inject.Inject
+
+class UploadConsultImagesUseCase @Inject constructor(
+    private val repository: ConsultRepository
+) {
+    suspend operator fun invoke(uris: List<String>, userId: String): List<String> = coroutineScope {
+        val deferredUploads = uris.map { uri ->
+            async {
+                repository.uploadImage(uri, userId)
+            }
+        }
+        deferredUploads.awaitAll()
+    }
+}

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/common/UiConst.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/common/UiConst.kt
@@ -1,9 +1,15 @@
 package com.moon.pharm.component_ui.common
 
+// 1. 날짜 및 시간 관련 (Date & Time)
 const val ASIA_SEOUL_ZONE = "Asia/Seoul"
 const val DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss"
 const val DATE_PATTERN = "yyyy.MM.dd"
 const val TIME_PATTERN = "a hh:mm"
 
+// 2. 문자열 처리용 구분자 (String Delimiters)
+const val PATH_DELIMITER = "/"
+const val QUERY_DELIMITER = "?"
+
+// 3. 위치 정보 기본값 (Location Defaults)
 const val DEFAULT_LAT_SEOUL = 37.5665
 const val DEFAULT_LNG_SEOUL = 126.9780

--- a/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMapper.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMapper.kt
@@ -1,5 +1,7 @@
 package com.moon.pharm.consult.mapper
 
+import com.moon.pharm.component_ui.common.PATH_DELIMITER
+import com.moon.pharm.component_ui.common.QUERY_DELIMITER
 import com.moon.pharm.consult.screen.ConsultWriteState
 import com.moon.pharm.domain.model.consult.ConsultImage
 import com.moon.pharm.domain.model.consult.ConsultItem
@@ -11,7 +13,8 @@ object ConsultUiMapper {
         writeState: ConsultWriteState,
         currentUserId: String,
         currentUserNickname: String,
-        selectedPharmacistId: String
+        selectedPharmacistId: String,
+        uploadedImageUrls: List<String>
     ): ConsultItem {
         return ConsultItem(
             id = "",
@@ -23,8 +26,11 @@ object ConsultUiMapper {
             status = ConsultStatus.WAITING,
             isPublic = writeState.isPublic,
             createdAt = System.currentTimeMillis(),
-            images = writeState.images.map { path ->
-                ConsultImage(path.substringAfterLast("/"), path)
+            images = uploadedImageUrls.map { url ->
+                ConsultImage(
+                    imageName = url.substringAfterLast(PATH_DELIMITER).substringBefore(QUERY_DELIMITER),
+                    imageUrl = url
+                )
             }
         )
     }


### PR DESCRIPTION
[feat: data]
- FirebaseStorage를 활용한 이미지 업로드 로직 추가 (ImageDataSource)
- 상담 등록 시 로컬 이미지를 Storage URL로 변환하여 저장하도록 개선

[refactor: consult]
- ViewModel의 submitConsult 리팩토링 및 로딩 상태 처리 강화
- 여러 장의 이미지 선택 및 업로드 지원 (awaitAll 활용)

Closes #25