### PR TITLE
fix(consult): 상담 등록 후 UI 유실 및 리스트 미갱신 버그 수정

### DIFF
--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultPharmacistScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultPharmacistScreen.kt
@@ -113,6 +113,7 @@ fun ConsultPharmacistScreen(
                         onPharmacistSelect = { pharmacist ->
                             viewModel.selectPharmacist(pharmacist.userId)
                             viewModel.selectPharmacist(pharmacist.userId)
+                            isMapView = false
                             navController.navigate(ContentNavigationRoute.ConsultTabConfirmScreen)
                         }
                     )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultViewModel.kt
@@ -349,20 +349,12 @@ class ConsultViewModel @Inject constructor(
             consultUseCases.createConsult(consultInfo).collectLatest { result ->
                 _uiState.update { state ->
                     when (result) {
-                        is DataResourceResult.Loading -> state.copy(
-                            isLoading = true,
-                            userMessage = null
-                        )
-
-                        is DataResourceResult.Success -> state.copy(
-                            isLoading = false,
-                            isConsultCreated = true
-                        )
-
-                        is DataResourceResult.Failure -> state.copy(
-                            isLoading = false,
-                            userMessage = ConsultUiMessage.CreateFailed
-                        )
+                        is DataResourceResult.Loading -> state.copy(isLoading = true, userMessage = null)
+                        is DataResourceResult.Success -> {
+                            fetchConsultList()
+                            state.copy(isLoading = false, isConsultCreated = true)
+                        }
+                        is DataResourceResult.Failure -> state.copy(isLoading = false, userMessage = ConsultUiMessage.CreateFailed)
                     }
                 }
             }


### PR DESCRIPTION
- 상담 등록 프로세스 중 지도 모드(isMapView)가 해제되지 않던 문제 해결
- 상담 글 생성 성공 시 리스트 새로고침(fetchConsultList) 로직 추가
- 네비게이션 복귀 시 UI와 데이터의 동기화 보장

Closes #27