### PR TITLE
feat(consult): 약사 답변 등록 기능 구현 및 AnswerSection UI 컴포넌트 분리

### DIFF
--- a/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
+++ b/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
@@ -1,19 +1,13 @@
 package com.moon.pharm.data.common
 
-// 1. 기본 유틸리티 (Basic Utilities)
+// 기본 유틸리티 (Basic Utilities)
 const val EMPTY_STRING = ""
 const val TIME_DELIMITER = ":"
 
-// 2. 위치 및 지도 설정 (Location & Maps)
+// 위치 및 지도 설정 (Location & Maps)
 const val DEFAULT_LOCATION_COORDINATE = 0.0
 
-// Google Places API 관련 설정
-const val PLACE_TYPE_PHARMACY = "PHARMACY"
-const val QUERY_PHARMACY_KOREAN = "약국"
-const val SEARCH_RADIUS_METERS = 1000.0
-const val SEARCH_MAX_RESULT_COUNT = 20
-
-// 3. Firestore 컬렉션 이름 (Collections)
+// Firestore 컬렉션 이름 (Collections)
 const val USER_COLLECTION = "users"
 const val PHARMACIST_COLLECTION = "pharmacists"
 const val PHARMACY_COLLECTION = "pharmacies"
@@ -22,7 +16,7 @@ const val CONSULT_COLLECTION = "consults"
 const val MEDICATION_COLLECTION = "medications"
 const val INTAKE_RECORDS_COLLECTION = "intakeRecords"
 
-// 4. Firestore 필드 및 문서 키 (Fields & Keys)
+// Firestore 필드 및 문서 키 (Fields & Keys)
 const val DOCUMENT_LIFESTYLE = "lifeStyle"
 
 const val FIELD_USER_ID = "userId"
@@ -33,13 +27,13 @@ const val FIELD_PLACE_ID = "placeId"
 const val FIELD_MEDICATION_ID = "medicationId"
 const val FIELD_SCHEDULE_ID = "scheduleId"
 const val FIELD_RECORD_DATE = "recordDate"
+const val FIELD_STATUS = "status"
+const val FIELD_ANSWER = "answer"
 
-// 5. 타입 및 상태 상수 (Types & Status)
-const val USER_TYPE_PHARMACIST = "PHARMACIST"
-
-// 6. 에러 메시지 (Error Messages)
+// 에러 메시지 (Error Messages)
 const val ERROR_MSG_PHARMACY_NOT_FOUND = "Pharmacy not found"
 const val ERROR_MSG_UPLOAD_FAILED = "Upload failed"
+const val ERROR_MSG_CONSULT_NOT_FOUND = "Consult document not found"
 
-// 7. Firebase Storage 설정 (Storage)
+// Firebase Storage 설정 (Storage)
 const val STORAGE_CONSULT_IMAGES = "consult_images"

--- a/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
@@ -1,10 +1,13 @@
 package com.moon.pharm.data.datasource
 
-import com.moon.pharm.domain.model.consult.ConsultItem
+import com.moon.pharm.data.datasource.remote.dto.ConsultAnswerDTO
+import com.moon.pharm.data.datasource.remote.dto.ConsultItemDTO
 import kotlinx.coroutines.flow.Flow
 
 interface ConsultDataSource {
-    suspend fun create(consult: ConsultItem)
-    fun getConsultItems(): Flow<List<ConsultItem>>
-    fun getConsultDetail(id: String): Flow<ConsultItem?>
+    suspend fun create(consult: ConsultItemDTO)
+    fun getConsultItems(): Flow<List<ConsultItemDTO>>
+    fun getConsultDetail(id: String): Flow<ConsultItemDTO?>
+
+    suspend fun updateConsultAnswer(consultId: String, answerDto: ConsultAnswerDTO): ConsultItemDTO
 }

--- a/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
@@ -1,15 +1,17 @@
 package com.moon.pharm.data.datasource.remote.firebase
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.snapshots
 import com.moon.pharm.data.common.CONSULT_COLLECTION
+import com.moon.pharm.data.common.ERROR_MSG_CONSULT_NOT_FOUND
+import com.moon.pharm.data.common.FIELD_ANSWER
 import com.moon.pharm.data.common.FIELD_CREATED_AT
+import com.moon.pharm.data.common.FIELD_STATUS
 import com.moon.pharm.data.datasource.ConsultDataSource
+import com.moon.pharm.data.datasource.remote.dto.ConsultAnswerDTO
 import com.moon.pharm.data.datasource.remote.dto.ConsultItemDTO
-import com.moon.pharm.data.mapper.toDomain
-import com.moon.pharm.data.mapper.toDomainList
-import com.moon.pharm.data.mapper.toDto
-import com.moon.pharm.domain.model.consult.ConsultItem
+import com.moon.pharm.domain.model.consult.ConsultStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -22,28 +24,46 @@ class FirestoreConsultDataSourceImpl @Inject constructor(
 
     private val collection = firestore.collection(CONSULT_COLLECTION)
 
-    override suspend fun create(consult: ConsultItem) {
+    override suspend fun create(consult: ConsultItemDTO) {
         val docRef = if (consult.id.isNotEmpty()) collection.document(consult.id)
         else collection.document()
 
-        val dataToSave = consult.copy(id = docRef.id).toDto()
+        val dataToSave = consult.copy(id = docRef.id)
         docRef.set(dataToSave).await()
     }
 
-    override fun getConsultItems(): Flow<List<ConsultItem>> =
+    override fun getConsultItems(): Flow<List<ConsultItemDTO>> =
         collection.orderBy(FIELD_CREATED_AT)
             .snapshots()
             .map { snapshot ->
-                snapshot.toObjects(ConsultItemDTO::class.java).toDomainList()
+                snapshot.toObjects(ConsultItemDTO::class.java)
             }
 
-    override fun getConsultDetail(id: String): Flow<ConsultItem?> = flow {
+    override fun getConsultDetail(id: String): Flow<ConsultItemDTO?> = flow {
         val snapshot = collection.document(id).get().await()
 
         if (snapshot.exists()) {
             val dto = snapshot.toObject(ConsultItemDTO::class.java)
-            val domain = dto?.toDomain()
-            emit(domain)
+            emit(dto)
         }
+    }
+
+    override suspend fun updateConsultAnswer(consultId: String, answerDto: ConsultAnswerDTO): ConsultItemDTO {
+        val consultRef = collection.document(consultId)
+        return firestore.runTransaction { transaction ->
+            val snapshot = transaction.get(consultRef)
+            val currentDto = snapshot.toObject(ConsultItemDTO::class.java)
+                ?: throw FirebaseFirestoreException(
+                    ERROR_MSG_CONSULT_NOT_FOUND,
+                    FirebaseFirestoreException.Code.NOT_FOUND
+                )
+
+            transaction.update(consultRef, FIELD_ANSWER, answerDto)
+            transaction.update(consultRef, FIELD_STATUS, ConsultStatus.COMPLETED.name)
+            currentDto.copy(
+                answer = answerDto,
+                status = ConsultStatus.COMPLETED.name
+            )
+        }.await()
     }
 }

--- a/data/src/main/java/com/moon/pharm/data/mapper/ConsultMapper.kt
+++ b/data/src/main/java/com/moon/pharm/data/mapper/ConsultMapper.kt
@@ -8,7 +8,6 @@ import com.moon.pharm.domain.model.consult.ConsultAnswer
 import com.moon.pharm.domain.model.consult.ConsultImage
 import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.model.consult.ConsultStatus
-import kotlin.collections.map
 
 fun ConsultItemDTO.toDomain(): ConsultItem {
     return ConsultItem(
@@ -61,6 +60,16 @@ fun ConsultAnswerDTO.toDomain(): ConsultAnswer {
         pharmacistName = this.pharmacistName,
         content = this.content,
         createdAt = this.createdAt?.toDate()?.time ?: 0L
+    )
+}
+
+fun ConsultAnswer.toDto(): ConsultAnswerDTO {
+    return ConsultAnswerDTO(
+        answerId = this.answerId,
+        pharmacistId = this.pharmacistId,
+        pharmacistName = this.pharmacistName,
+        content = this.content,
+        createdAt = this.createdAt.toTimestamp()
     )
 }
 

--- a/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
@@ -1,5 +1,6 @@
 package com.moon.pharm.domain.repository
 
+import com.moon.pharm.domain.model.consult.ConsultAnswer
 import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.result.DataResourceResult
 import kotlinx.coroutines.flow.Flow
@@ -8,5 +9,6 @@ interface ConsultRepository {
     fun createConsult(consultInfo: ConsultItem): Flow<DataResourceResult<Unit>>
     fun getConsultItems(): Flow<DataResourceResult<List<ConsultItem>>>
     fun getConsultDetail(id: String): Flow<DataResourceResult<ConsultItem>>
+    fun registerAnswer(consultId: String, answer: ConsultAnswer): Flow<DataResourceResult<ConsultItem>>
     suspend fun uploadImage(uri: String, userId: String): String
 }

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/ConsultUseCases.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/ConsultUseCases.kt
@@ -10,6 +10,7 @@ data class ConsultUseCases @Inject constructor(
     val getConsultList: GetConsultItemsUseCase,
     val getConsultDetail: GetConsultDetailUseCase,
     val createConsult: CreateConsultUseCase,
+    val registerAnswer: RegisterAnswerUseCase,
 
     val searchPharmacy: SearchPharmacyUseCase,
     val searchNearbyPharmacies: SearchNearbyPharmaciesUseCase,

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultDetailUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultDetailUseCase.kt
@@ -2,8 +2,10 @@ package com.moon.pharm.domain.usecase.consult
 
 import com.moon.pharm.domain.model.auth.Pharmacist
 import com.moon.pharm.domain.model.consult.ConsultItem
+import com.moon.pharm.domain.model.consult.ConsultStatus
 import com.moon.pharm.domain.repository.ConsultRepository
 import com.moon.pharm.domain.result.DataResourceResult
+import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.moon.pharm.domain.usecase.pharmacist.GetPharmacistDetailUseCase
 import com.moon.pharm.domain.usecase.user.GetNicknameUseCase
 import kotlinx.coroutines.flow.Flow
@@ -14,13 +16,15 @@ import javax.inject.Inject
 
 data class ConsultDetailResult(
     val consult: ConsultItem,
-    val pharmacist: Pharmacist?
+    val pharmacist: Pharmacist?,
+    val isMyConsultToAnswer: Boolean
 )
 
 class GetConsultDetailUseCase @Inject constructor(
     private val consultRepository: ConsultRepository,
     private val getNicknameUseCase: GetNicknameUseCase,
-    val getPharmacistDetail: GetPharmacistDetailUseCase
+    private val getPharmacistDetail: GetPharmacistDetailUseCase,
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
 ) {
     operator fun invoke(id: String): Flow<DataResourceResult<ConsultDetailResult>> = flow {
         emit(DataResourceResult.Loading)
@@ -33,18 +37,23 @@ class GetConsultDetailUseCase @Inject constructor(
             val originConsult = consultResult.resultData
             val nickName = getNicknameUseCase.getNickname(originConsult.userId)
             val consult = originConsult.copy(nickName = nickName)
-            var pharmacist: Pharmacist? = null
 
-            consult.answer?.let { answer ->
-                val pharmacistResult = getPharmacistDetail(answer.pharmacistId)
+            var pharmacist: Pharmacist? = null
+            originConsult.pharmacistId?.let { pId ->
+                val pharmacistResult = getPharmacistDetail(pId)
                     .filter { it !is DataResourceResult.Loading }
                     .first()
-
                 if (pharmacistResult is DataResourceResult.Success) {
                     pharmacist = pharmacistResult.resultData
                 }
             }
-            emit(DataResourceResult.Success(ConsultDetailResult(consult, pharmacist)))
+
+            val currentUserId = getCurrentUserIdUseCase()
+            val canAnswer = currentUserId != null &&
+                    currentUserId == originConsult.pharmacistId &&
+                    originConsult.status == ConsultStatus.WAITING
+
+            emit(DataResourceResult.Success(ConsultDetailResult(consult, pharmacist, canAnswer)))
         } else if (consultResult is DataResourceResult.Failure) {
             emit(DataResourceResult.Failure(consultResult.exception))
         }

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/RegisterAnswerUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/RegisterAnswerUseCase.kt
@@ -1,0 +1,48 @@
+package com.moon.pharm.domain.usecase.consult
+
+import com.moon.pharm.domain.model.auth.Pharmacist
+import com.moon.pharm.domain.model.consult.ConsultAnswer
+import com.moon.pharm.domain.model.consult.ConsultItem
+import com.moon.pharm.domain.repository.ConsultRepository
+import com.moon.pharm.domain.result.DataResourceResult
+import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
+import com.moon.pharm.domain.usecase.pharmacist.GetPharmacistDetailUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RegisterAnswerUseCase @Inject constructor(
+    private val repository: ConsultRepository,
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
+    private val getPharmacistDetailUseCase: GetPharmacistDetailUseCase
+) {
+    operator fun invoke(consultId: String, content: String, pharmacist: Pharmacist): Flow<DataResourceResult<ConsultItem>> = flow {
+        emit(DataResourceResult.Loading)
+
+        val currentUserId = getCurrentUserIdUseCase()
+        if (currentUserId == null) {
+            emit(DataResourceResult.Failure(Exception("User not logged in")))
+            return@flow
+        }
+
+        val pharmacistResult = getPharmacistDetailUseCase(currentUserId).first()
+        if (pharmacistResult is DataResourceResult.Success) {
+            val pharmacist = pharmacistResult.resultData
+            val newAnswer = ConsultAnswer(
+                answerId = java.util.UUID.randomUUID().toString(),
+                pharmacistId = pharmacist.userId,
+                pharmacistName = pharmacist.name,
+                userInfo = null,
+                content = content,
+                createdAt = System.currentTimeMillis()
+            )
+
+            repository.registerAnswer(consultId, newAnswer).collect { result ->
+                emit(result)
+            }
+        } else {
+            emit(DataResourceResult.Failure(Exception("Failed to load pharmacist info")))
+        }
+    }
+}

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
@@ -36,7 +36,8 @@ fun PrimaryTextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     height: Dp = 50.dp,
-    shape: Shape = RoundedCornerShape(10.dp)
+    shape: Shape = RoundedCornerShape(10.dp),
+    contentAlignment: Alignment = Alignment.CenterStart
 ) {
     if (value != null) {
         BasicTextField(
@@ -55,7 +56,7 @@ fun PrimaryTextField(
             decorationBox = { innerTextField ->
                 Box(
                     modifier = Modifier.padding(horizontal = 16.dp),
-                    contentAlignment = Alignment.CenterStart
+                    contentAlignment = contentAlignment
                 ) {
                     if (value.isEmpty()) {
                         Text(

--- a/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMessageMapper.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMessageMapper.kt
@@ -2,9 +2,9 @@ package com.moon.pharm.consult.mapper
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.moon.pharm.component_ui.R as UiR
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.model.ConsultUiMessage
+import com.moon.pharm.component_ui.R as UiR
 
 @Composable
 fun ConsultUiMessage.asString(): String {
@@ -14,5 +14,6 @@ fun ConsultUiMessage.asString(): String {
         ConsultUiMessage.PharmacistRequired -> stringResource(R.string.consult_error_pharmacist_required)
         ConsultUiMessage.LoginRequired -> stringResource(UiR.string.error_login_required)
         ConsultUiMessage.CreateFailed -> stringResource(R.string.consult_create_failed)
+        ConsultUiMessage.AnswerRegisterSuccess -> stringResource(R.string.consult_answer_success)
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/model/ConsultUiMessage.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/model/ConsultUiMessage.kt
@@ -8,4 +8,5 @@ sealed interface ConsultUiMessage : UiMessage {
     data object PharmacistRequired : ConsultUiMessage
     data object LoginRequired : ConsultUiMessage
     data object CreateFailed : ConsultUiMessage
+    data object AnswerRegisterSuccess : ConsultUiMessage
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultDetailScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultDetailScreen.kt
@@ -3,6 +3,7 @@ package com.moon.pharm.consult.screen
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -13,6 +14,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.moon.pharm.component_ui.component.bar.PharmTopBar
+import com.moon.pharm.component_ui.component.snackbar.CustomSnackbar
+import com.moon.pharm.component_ui.component.snackbar.SnackbarType
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
 import com.moon.pharm.consult.R
@@ -28,6 +31,8 @@ fun ConsultDetailScreen(
     viewModel: ConsultViewModel
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val answerContent by viewModel.answerContent.collectAsStateWithLifecycle()
+    val isPharmacistMode = uiState.canAnswer
     val snackbarHostState = remember { SnackbarHostState() }
 
     val userMessage = uiState.userMessage
@@ -56,14 +61,23 @@ fun ConsultDetailScreen(
                 )
             )
         },
-        snackbarHost = {}
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                CustomSnackbar(snackbarData = data, type = SnackbarType.ERROR)
+            }
+        }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             ConsultDetailContent(
                 isLoading = uiState.isLoading,
                 item = uiState.selectedItem,
                 pharmacist = uiState.answerPharmacist,
-                pharmacistImageUrl = uiState.answerPharmacistProfileUrl
+                pharmacistImageUrl = uiState.answerPharmacistProfileUrl,
+
+                isPharmacistMode = isPharmacistMode,
+                answerInput = answerContent,
+                onAnswerChange = viewModel::onAnswerContentChanged,
+                onSubmitAnswer = { viewModel.registerAnswer(consultId)}
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultUiState.kt
@@ -2,8 +2,8 @@ package com.moon.pharm.consult.screen
 
 import com.moon.pharm.component_ui.common.UiMessage
 import com.moon.pharm.consult.model.ConsultPrimaryTab
-import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.model.auth.Pharmacist
+import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 
 data class ConsultUiState (
@@ -17,6 +17,7 @@ data class ConsultUiState (
     val selectedItem: ConsultItem? = null,
     val answerPharmacist: Pharmacist? = null,
     val answerPharmacistProfileUrl: String? = null,
+    val canAnswer: Boolean = false,
 
     val writeState: ConsultWriteState = ConsultWriteState()
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/AnswerContentCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/AnswerContentCard.kt
@@ -1,0 +1,52 @@
+package com.moon.pharm.consult.screen.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.util.toDisplayDateTimeString
+import com.moon.pharm.consult.R
+import com.moon.pharm.domain.model.consult.ConsultAnswer
+
+@Composable
+fun AnswerContentCard(
+    answer: ConsultAnswer
+) {
+    Surface(
+        shape = RoundedCornerShape(10.dp),
+        color = White,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = answer.content,
+                fontSize = 14.sp,
+                color = Color.Black,
+                lineHeight = 22.sp
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.consult_detail_answer_date_format,
+                    answer.createdAt.toDisplayDateTimeString()
+                ),
+                fontSize = 12.sp,
+                color = SecondFont
+            )
+        }
+    }
+}

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
@@ -19,6 +19,7 @@ import com.moon.pharm.component_ui.theme.SecondFont
 import com.moon.pharm.component_ui.theme.backgroundLight
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.screen.section.AnswerSection
+import com.moon.pharm.consult.screen.section.PharmacistAnswerInputSection
 import com.moon.pharm.consult.screen.section.QuestionSection
 import com.moon.pharm.domain.model.auth.Pharmacist
 import com.moon.pharm.domain.model.consult.ConsultItem
@@ -29,7 +30,12 @@ fun ConsultDetailContent(
     isLoading: Boolean,
     item: ConsultItem?,
     pharmacist: Pharmacist?,
-    pharmacistImageUrl: String?
+    pharmacistImageUrl: String?,
+
+    isPharmacistMode: Boolean = false,
+    answerInput: String = "",
+    onAnswerChange: (String) -> Unit = {},
+    onSubmitAnswer: () -> Unit = {}
 ) {
     if (item != null) {
         LazyColumn(
@@ -51,9 +57,18 @@ fun ConsultDetailContent(
                     )
                 } else if (item.status == ConsultStatus.WAITING) {
                     Spacer(modifier = Modifier.height(20.dp))
-                    WaitingForAnswerBox()
+                    if (isPharmacistMode) {
+                        PharmacistAnswerInputSection(
+                            input = answerInput,
+                            onValueChange = onAnswerChange,
+                            onSubmit = onSubmitAnswer
+                        )
+                    } else {
+                        WaitingForAnswerBox()
+                    }
                 }
             }
+            item { Spacer(modifier = Modifier.height(50.dp)) }
         }
     } else if (!isLoading) {
         Box(

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
@@ -64,7 +65,8 @@ fun ConsultWriteForm(
             singleLine = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(250.dp)
+                .height(250.dp),
+            contentAlignment = Alignment.TopStart
         )
 
         Spacer(modifier = Modifier.height(10.dp))

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileCard.kt
@@ -1,0 +1,56 @@
+package com.moon.pharm.consult.screen.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.consult.R
+import com.moon.pharm.domain.model.auth.Pharmacist
+
+@Composable
+fun PharmacistProfileCard(
+    pharmacist: Pharmacist?,
+    pharmacistImageUrl: String?
+) {
+    Surface(
+        shape = RoundedCornerShape(10.dp),
+        color = White,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (pharmacist != null) {
+                PharmacistProfileImage(imageUrl = pharmacistImageUrl)
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Text(
+                    text = pharmacist.name,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.consult_detail_no_pharmacist_info),
+                    fontSize = 13.sp,
+                    color = SecondFont
+                )
+            }
+        }
+    }
+}

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileImage.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileImage.kt
@@ -1,0 +1,50 @@
+package com.moon.pharm.consult.screen.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.moon.pharm.consult.R
+
+@Composable
+fun PharmacistProfileImage(imageUrl: String?) {
+    if (!imageUrl.isNullOrBlank()) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = stringResource(R.string.consult_detail_pharmacist_profile_desc),
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+            error = rememberVectorPainter(Icons.Default.Person),
+            placeholder = rememberVectorPainter(Icons.Default.Person)
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(Color.LightGray),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Person,
+                contentDescription = null,
+                tint = Color.White
+            )
+        }
+    }
+}

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/AnswerSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/AnswerSection.kt
@@ -1,37 +1,19 @@
 package com.moon.pharm.consult.screen.section
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil3.compose.AsyncImage
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.util.toDisplayDateTimeString
 import com.moon.pharm.consult.R
+import com.moon.pharm.consult.screen.component.AnswerContentCard
+import com.moon.pharm.consult.screen.component.PharmacistProfileCard
 import com.moon.pharm.domain.model.auth.Pharmacist
 import com.moon.pharm.domain.model.consult.ConsultItem
 
@@ -51,88 +33,15 @@ fun AnswerSection(
             modifier = Modifier.padding(bottom = 10.dp)
         )
 
-        Surface(
-            shape = RoundedCornerShape(10.dp),
-            color = White,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Row(
-                modifier = Modifier.padding(10.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (pharmacist != null) {
-                    if (!pharmacistImageUrl.isNullOrBlank()) {
-                        AsyncImage(
-                            model = pharmacistImageUrl,
-                            contentDescription = stringResource(R.string.consult_detail_pharmacist_profile_desc),
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(CircleShape),
-                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                            error = rememberVectorPainter(Icons.Default.Person),
-                            placeholder = rememberVectorPainter(Icons.Default.Person)
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(CircleShape)
-                                .background(Color.LightGray),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Person,
-                                contentDescription = null,
-                                tint = Color.White
-                            )
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.width(10.dp))
-
-                    Column {
-                        Text(
-                            text = pharmacist.name,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 14.sp
-                        )
-                    }
-                } else {
-                    Text(
-                        text = stringResource(R.string.consult_detail_no_pharmacist_info),
-                        fontSize = 13.sp,
-                        color = SecondFont
-                    )
-                }
-            }
-        }
+        PharmacistProfileCard(
+            pharmacist = pharmacist,
+            pharmacistImageUrl = pharmacistImageUrl
+        )
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        Surface(
-            shape = RoundedCornerShape(10.dp),
-            color = White,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(modifier = Modifier.padding(20.dp)) {
-                Text(
-                    text = answer.content,
-                    fontSize = 14.sp,
-                    color = Color.Black,
-                    lineHeight = 22.sp
-                )
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Text(
-                    text = stringResource(
-                        R.string.consult_detail_answer_date_format,
-                        answer.createdAt.toDisplayDateTimeString()
-                    ),
-                    fontSize = 12.sp,
-                    color = SecondFont
-                )
-            }
-        }
+        AnswerContentCard(
+            answer = answer
+        )
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
@@ -1,0 +1,71 @@
+package com.moon.pharm.consult.screen.section
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
+import com.moon.pharm.component_ui.component.input.PrimaryTextField
+import com.moon.pharm.component_ui.theme.Primary
+import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.consult.R
+
+@Composable
+fun PharmacistAnswerInputSection(
+    input: String,
+    onValueChange: (String) -> Unit,
+    onSubmit: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(White, RoundedCornerShape(10.dp))
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "약사님, 답변을 등록해주세요",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
+            color = Primary
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        PrimaryTextField(
+            value = input,
+            onValueChange = onValueChange,
+            placeholder = stringResource(R.string.consult_answer_write_placeholder_content),
+            textStyle = TextStyle(
+                fontSize = 16.sp,
+                color = primaryLight,
+                lineHeight = 24.sp
+            ),
+            singleLine = false,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(250.dp),
+            contentAlignment = Alignment.TopStart
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PharmPrimaryButton(
+            text = "답변 등록하기",
+            onClick = onSubmit,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = input.isNotBlank()
+        )
+    }
+}

--- a/features/consult/src/main/res/values/strings.xml
+++ b/features/consult/src/main/res/values/strings.xml
@@ -1,12 +1,12 @@
 <resources>
-    <!-- Error -->
+    <!--  Error  -->
     <string name="error_create_consult">상담 등록 실패</string>
     <string name="consult_error_input_required">제목과 내용을 입력해주세요.</string>
     <string name="consult_error_pharmacist_required">상담할 약사를 선택해주세요.</string>
     <string name="consult_error_title_short">제목은 최소 5자 이상 입력해주세요.</string>
     <string name="consult_create_failed">상담 등록에 실패했습니다. 다시 시도해주세요.</string>
 
-    <!-- ConsultList -->
+    <!--  ConsultList  -->
     <string name="consult_board_title">상담 게시판</string>
     <string name="consult_write_title">상담글 작성</string>
     <string name="consult_meta_format">%1$s • %2$s</string>
@@ -27,7 +27,7 @@
     <string name="consult_status_waiting_title">약사님의 답변을 기다리고 있어요.</string>
     <string name="consult_status_waiting_subtitle">답변이 등록되면 알림을 통해 알려드리겠습니다.</string>
 
-    <!-- WriteScreen -->
+    <!--  WriteScreen  -->
     <string name="consult_write_placeholder_title">제목을 입력해주세요</string>
     <string name="consult_write_placeholder_content">구체적인 증상, 복용 중인 다른 약물 정보 등을 자세히 작성해주세요.</string>
     <string name="consult_write_public_setting_title">공개 설정</string>
@@ -40,13 +40,13 @@
 
     <string name="consult_button_next">다음</string>
 
-    <!-- PharmacistScreen -->
+    <!--  PharmacistScreen  -->
     <string name="consult_search_select_pharmacist">약사 선택</string>
     <string name="consult_search_placeholder">지역, 약국명, 약사 전문 분야 검색</string>
     <string name="consult_search_nearby">내 주변</string>
     <string name="consult_search_favorite">단골 약사</string>
 
-    <!-- ConfirmScreen -->
+    <!--  ConfirmScreen  -->
     <string name="consult_write_empty_value">아직 작성되지 않음</string>
 
     <string name="consult_confirm_title">약사 최종 검토 및 요청</string>
@@ -61,7 +61,7 @@
     </string>
     <string name="consult_confirm_submit_btn">상담 요청하기</string>
 
-    <!-- Map -->
+    <!--  Map  -->
     <string name="consult_map_search_placeholder">지도를 열어 약사 찾기</string>
     <string name="consult_map_pharmacy_default_name">약국</string>
     <string name="consult_map_select_btn">선택</string>
@@ -69,4 +69,8 @@
     <string name="consult_map_no_pharmacist">등록된 약사가 없습니다.</string>
 
     <string name="desc_map_icon">지도</string>
+
+    <!--  Answer  -->
+    <string name="consult_answer_success">답변이 등록되었습니다.</string>
+    <string name="consult_answer_write_placeholder_content">답변을 작성해주세요.</string>
 </resources>


### PR DESCRIPTION
- RegisterAnswerUseCase 구현 및 답변 등록 로직 추가
- GetConsultDetailUseCase에 답변 권한(canAnswer) 체크 로직 추가
- Firestore 트랜잭션을 통한 데이터 무결성 보장
- ConsultDetailScreen 내 약사 전용 입력창 UI 분기 처리
- AnswerSection을 독립된 컴포넌트로 분리 (PharmacistProfileCard, AnswerContentCard)

Closes : #30