### PR TITLE
feat(mypage): 약사 '나의 답변 내역' 구현 및 마이페이지 로직 리팩토링

### DIFF
--- a/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
+++ b/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
@@ -20,6 +20,7 @@ const val INTAKE_RECORDS_COLLECTION = "intakeRecords"
 const val DOCUMENT_LIFESTYLE = "lifeStyle"
 
 const val FIELD_USER_ID = "userId"
+const val FIELD_PHARMACIST_ID = "pharmacistId"
 const val FIELD_USER_EMAIL = "email"
 const val FIELD_CREATED_AT = "createdAt"
 const val FIELD_USER_TYPE = "userType"

--- a/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
@@ -9,6 +9,7 @@ interface ConsultDataSource {
     fun getConsultItems(): Flow<List<ConsultItemDTO>>
     fun getConsultDetail(id: String): Flow<ConsultItemDTO?>
     fun getMyConsults(userId: String): Flow<List<ConsultItemDTO>>
+    fun getMyAnsweredConsults(pharmacistId: String): Flow<List<ConsultItemDTO>>
 
     suspend fun updateConsultAnswer(consultId: String, answerDto: ConsultAnswerDTO): ConsultItemDTO
 }

--- a/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.moon.pharm.data.common.CONSULT_COLLECTION
 import com.moon.pharm.data.common.ERROR_MSG_CONSULT_NOT_FOUND
 import com.moon.pharm.data.common.FIELD_ANSWER
 import com.moon.pharm.data.common.FIELD_CREATED_AT
+import com.moon.pharm.data.common.FIELD_PHARMACIST_ID
 import com.moon.pharm.data.common.FIELD_STATUS
 import com.moon.pharm.data.common.FIELD_USER_ID
 import com.moon.pharm.data.datasource.ConsultDataSource
@@ -53,6 +54,15 @@ class FirestoreConsultDataSourceImpl @Inject constructor(
     override fun getMyConsults(userId: String): Flow<List<ConsultItemDTO>> =
         collection
             .whereEqualTo(FIELD_USER_ID, userId)
+            .orderBy(FIELD_CREATED_AT, Query.Direction.DESCENDING)
+            .snapshots()
+            .map { snapshot ->
+                snapshot.toObjects(ConsultItemDTO::class.java)
+            }
+
+    override fun getMyAnsweredConsults(pharmacistId: String): Flow<List<ConsultItemDTO>> =
+        collection
+            .whereEqualTo(FIELD_PHARMACIST_ID, pharmacistId)
             .orderBy(FIELD_CREATED_AT, Query.Direction.DESCENDING)
             .snapshots()
             .map { snapshot ->

--- a/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
@@ -88,6 +88,17 @@ class ConsultRepositoryImpl @Inject constructor(
             .flowOn(ioDispatcher)
     }
 
+    override fun getMyAnsweredConsultList(userId: String): Flow<DataResourceResult<List<ConsultItem>>> {
+        return dataSource.getMyAnsweredConsults(userId)
+            .map { dtoList ->
+                val domainList = dtoList.map { it.toDomain() }
+                DataResourceResult.Success(domainList) as DataResourceResult<List<ConsultItem>>
+            }
+            .onStart { emit(DataResourceResult.Loading) }
+            .catch { emit(DataResourceResult.Failure(it)) }
+            .flowOn(ioDispatcher)
+    }
+
     override fun registerAnswer(
         consultId: String,
         answer: ConsultAnswer

--- a/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
@@ -10,6 +10,7 @@ interface ConsultRepository {
     fun getConsultItems(): Flow<DataResourceResult<List<ConsultItem>>>
     fun getConsultDetail(id: String): Flow<DataResourceResult<ConsultItem>>
     fun getMyConsult(userId: String): Flow<DataResourceResult<List<ConsultItem>>>
+    fun getMyAnsweredConsultList(userId: String): Flow<DataResourceResult<List<ConsultItem>>>
     fun registerAnswer(consultId: String, answer: ConsultAnswer): Flow<DataResourceResult<ConsultItem>>
     suspend fun uploadImage(uri: String, userId: String): String
 

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetMyAnsweredConsultUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetMyAnsweredConsultUseCase.kt
@@ -1,0 +1,15 @@
+package com.moon.pharm.domain.usecase.consult
+
+import com.moon.pharm.domain.model.consult.ConsultItem
+import com.moon.pharm.domain.repository.ConsultRepository
+import com.moon.pharm.domain.result.DataResourceResult
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMyAnsweredConsultUseCase @Inject constructor(
+    private val repository: ConsultRepository
+) {
+    operator fun invoke(userId: String): Flow<DataResourceResult<List<ConsultItem>>> {
+        return repository.getMyAnsweredConsultList(userId)
+    }
+}

--- a/features/component-ui/src/main/res/values/strings.xml
+++ b/features/component-ui/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
 
     <string name="search_result_count_format">검색 결과 %d건</string>
     <string name="search_result_empty">검색된 약국이 없습니다.</string>
+
+    <!-- Consult -->
+    <string name="my_consult_title">나의 상담 내역</string>
+    <string name="my_answer_title">나의 답변 내역</string>
 </resources>

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultEmptyView.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultEmptyView.kt
@@ -3,17 +3,16 @@ package com.moon.pharm.consult.screen.component
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
-import com.moon.pharm.consult.R
+import com.moon.pharm.component_ui.theme.SecondFont
 
 @Composable
 fun MyConsultEmptyView(
+    text: String,
     modifier: Modifier = Modifier
 ) {
     Text(
-        text = stringResource(R.string.my_consult_empty),
+        text = text,
         modifier = modifier,
-        color = Color.Gray
+        color = SecondFont
     )
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/my/MyConsultListScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/my/MyConsultListScreen.kt
@@ -23,11 +23,13 @@ import com.moon.pharm.component_ui.component.snackbar.CustomSnackbar
 import com.moon.pharm.component_ui.component.snackbar.SnackbarType
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
-import com.moon.pharm.consult.R
 import com.moon.pharm.consult.screen.component.MyConsultEmptyView
 import com.moon.pharm.consult.screen.component.MyConsultListContent
+import com.moon.pharm.consult.util.myConsultListEmptyTextRes
+import com.moon.pharm.consult.util.myConsultListTitleRes
 import com.moon.pharm.consult.viewmodel.MyConsultListUiState
 import com.moon.pharm.consult.viewmodel.MyConsultListViewModel
+import com.moon.pharm.domain.model.auth.UserType
 
 @Composable
 fun MyConsultListRoute(
@@ -64,11 +66,13 @@ fun MyConsultListScreen(
     onNavigateUp: () -> Unit,
     onItemClick: (String) -> Unit
 ) {
+    val userType = if (uiState.isPharmacist) UserType.PHARMACIST else UserType.GENERAL
+
     Scaffold(
         topBar = {
             PharmTopBar(
                 data = TopBarData(
-                    title = stringResource(R.string.my_consult_title),
+                    title = stringResource(userType.myConsultListTitleRes),
                     navigationType = TopBarNavigationType.Back,
                     onNavigationClick = onNavigateUp
                 )
@@ -90,7 +94,10 @@ fun MyConsultListScreen(
                     CircularProgressBar(modifier = Modifier.align(Alignment.Center))
                 }
                 uiState.myConsults.isEmpty() -> {
-                    MyConsultEmptyView(modifier = Modifier.align(Alignment.Center))
+                    MyConsultEmptyView(
+                        text = stringResource(userType.myConsultListEmptyTextRes),
+                        modifier = Modifier.align(Alignment.Center)
+                    )
                 }
                 else -> {
                     MyConsultListContent(

--- a/features/consult/src/main/java/com/moon/pharm/consult/util/UserTypeExtensions.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/util/UserTypeExtensions.kt
@@ -1,0 +1,17 @@
+package com.moon.pharm.consult.util
+
+import com.moon.pharm.consult.R
+import com.moon.pharm.domain.model.auth.UserType
+import com.moon.pharm.component_ui.R as UiR
+
+val UserType.myConsultListTitleRes: Int
+    get() = when (this) {
+        UserType.PHARMACIST -> UiR.string.my_answer_title
+        UserType.GENERAL -> UiR.string.my_consult_title
+    }
+
+val UserType.myConsultListEmptyTextRes: Int
+    get() = when (this) {
+        UserType.PHARMACIST -> R.string.my_answer_empty
+        UserType.GENERAL -> R.string.my_consult_empty
+    }

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListUiState.kt
@@ -6,5 +6,6 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 data class MyConsultListUiState(
     val isLoading: Boolean = false,
     val userMessage: UiMessage? = null,
-    val myConsults: List<ConsultItem> = emptyList()
+    val myConsults: List<ConsultItem> = emptyList(),
+    val isPharmacist: Boolean = false
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListViewModel.kt
@@ -3,14 +3,18 @@ package com.moon.pharm.consult.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moon.pharm.component_ui.common.UiMessage
+import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.domain.result.DataResourceResult
 import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
+import com.moon.pharm.domain.usecase.consult.GetMyAnsweredConsultUseCase
 import com.moon.pharm.domain.usecase.consult.GetMyConsultUseCase
+import com.moon.pharm.domain.usecase.user.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,7 +22,9 @@ import javax.inject.Inject
 @HiltViewModel
 class MyConsultListViewModel @Inject constructor(
     private val getMyConsultUseCase: GetMyConsultUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
+    private val getMyAnsweredConsultUseCase: GetMyAnsweredConsultUseCase,
+    private val getUserUseCase: GetUserUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MyConsultListUiState(isLoading = true))
@@ -42,25 +48,35 @@ class MyConsultListViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            getMyConsultUseCase(userId).collectLatest { result ->
+            val userResult = getUserUseCase(userId).first()
+
+            val isPharmacist = if (userResult is DataResourceResult.Success) {
+                userResult.resultData.userType == UserType.PHARMACIST
+            } else {
+                false
+            }
+
+            val consultFlow = if (isPharmacist) {
+                getMyAnsweredConsultUseCase(userId)
+            } else {
+                getMyConsultUseCase(userId)
+            }
+
+            consultFlow.collectLatest { result ->
                 _uiState.update { state ->
                     when (result) {
-                        is DataResourceResult.Loading -> {
-                            state.copy(isLoading = true)
-                        }
-                        is DataResourceResult.Success -> {
-                            state.copy(
-                                isLoading = false,
-                                myConsults = result.resultData,
-                                userMessage = null
-                            )
-                        }
-                        is DataResourceResult.Failure -> {
-                            state.copy(
-                                isLoading = false,
-                                userMessage = if (state.myConsults.isEmpty()) UiMessage.LoadDataFailed else null
-                            )
-                        }
+                        is DataResourceResult.Loading -> state.copy(isLoading = true)
+                        is DataResourceResult.Success -> state.copy(
+                            isLoading = false,
+                            myConsults = result.resultData,
+                            userMessage = null,
+                            isPharmacist = isPharmacist
+                        )
+                        is DataResourceResult.Failure -> state.copy(
+                            isLoading = false,
+                            userMessage = if (state.myConsults.isEmpty()) UiMessage.LoadDataFailed else null,
+                            isPharmacist = isPharmacist
+                        )
                     }
                 }
             }

--- a/features/consult/src/main/res/values/strings.xml
+++ b/features/consult/src/main/res/values/strings.xml
@@ -27,8 +27,8 @@
     <string name="consult_status_waiting_title">약사님의 답변을 기다리고 있어요.</string>
     <string name="consult_status_waiting_subtitle">답변이 등록되면 알림을 통해 알려드리겠습니다.</string>
 
-    <string name="my_consult_title">나의 상담 내역</string>
     <string name="my_consult_empty">작성한 상담 내역이 없습니다.</string>
+    <string name="my_answer_empty">작성한 답변 내역이 없습니다.</string>
 
     <!--  WriteScreen  -->
     <string name="consult_write_placeholder_title">제목을 입력해주세요</string>

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/MyPageScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/MyPageScreen.kt
@@ -42,6 +42,7 @@ import com.moon.pharm.profile.mypage.screen.component.MyPageMenuSection
 import com.moon.pharm.profile.mypage.screen.component.MyPageProfileCard
 import com.moon.pharm.profile.mypage.viewmodel.MyPageUiState
 import com.moon.pharm.profile.mypage.viewmodel.MyPageViewModel
+import com.moon.pharm.profile.util.myPageConsultMenuTitleRes
 import com.moon.pharm.component_ui.R as UiR
 
 @Composable
@@ -102,15 +103,19 @@ fun MyPageScreen(
                 ) {
                     MyPageProfileCard(user = user)
 
-                    val consultCount = uiState.myConsults.size
-                    val consultTitle = if (consultCount > 0)
-                        stringResource(R.string.mypage_consult_history_format, consultCount)
-                    else
-                        stringResource(R.string.mypage_consult_history)
+                    val baseTitle = stringResource(user.userType.myPageConsultMenuTitleRes)
+
+                    val formattedCount = uiState.consultHistoryText?.let {
+                        stringResource(R.string.mypage_consult_history_format, it)
+                    }
 
                     MyPageMenuSection(
                         title = stringResource(R.string.mypage_menu_core_feature),
-                        items = getCoreMenuItems(consultTitle, onNavigateToMyConsultation)
+                        items = getCoreMenuItems(
+                            consultTitle = baseTitle,
+                            consultCount = formattedCount,
+                            onConsultClick = onNavigateToMyConsultation
+                        )
                     )
 
                     MyPageMenuSection(
@@ -135,6 +140,7 @@ fun MyPageScreen(
 @Composable
 private fun getCoreMenuItems(
     consultTitle: String,
+    consultCount: String?,
     onConsultClick: () -> Unit
 ): List<MyPageMenuItemData> {
     return listOf(
@@ -151,6 +157,7 @@ private fun getCoreMenuItems(
         MyPageMenuItemData(
             icon = Icons.Outlined.Person,
             title = consultTitle,
+            count = consultCount,
             onClick = onConsultClick
         )
     )

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuItemData.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuItemData.kt
@@ -5,5 +5,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 data class MyPageMenuItemData(
     val icon: ImageVector,
     val title: String,
+    val count: String? = null,
     val onClick: () -> Unit
 )

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuSection.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -92,13 +91,27 @@ private fun MenuRowItem(item: MyPageMenuItemData) {
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        Text(
-            text = item.title,
+        Row(
             modifier = Modifier.weight(1f),
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Medium,
-            color = Primary
-        )
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = item.title,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = Primary
+            )
+
+            if (!item.count.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = item.count,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Normal,
+                    color = SecondFont
+                )
+            }
+        }
 
         Icon(
             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageUiState.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageUiState.kt
@@ -7,9 +7,10 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 
 data class MyPageUiState(
     val isLoading: Boolean = true,
+    val userMessage: UiMessage? = null,
     val user: User? = null,
     val myConsults: List<ConsultItem> = emptyList(),
-    val userMessage: UiMessage? = null,
+    val consultHistoryText: String? = null,
 
     val menuItems: List<MyPageMenuState> = emptyList(),
     val supportItems: List<MyPageMenuState> = emptyList()

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageViewModel.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageViewModel.kt
@@ -3,16 +3,22 @@ package com.moon.pharm.profile.mypage.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moon.pharm.component_ui.common.UiMessage
+import com.moon.pharm.domain.model.auth.UserType
+import com.moon.pharm.domain.model.consult.ConsultStatus
 import com.moon.pharm.domain.result.DataResourceResult
 import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.moon.pharm.domain.usecase.auth.LogoutUseCase
+import com.moon.pharm.domain.usecase.consult.GetMyAnsweredConsultUseCase
 import com.moon.pharm.domain.usecase.consult.GetMyConsultUseCase
 import com.moon.pharm.domain.usecase.user.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -21,6 +27,7 @@ class MyPageViewModel @Inject constructor(
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
     private val getUserUseCase: GetUserUseCase,
     private val getMyConsultUseCase: GetMyConsultUseCase,
+    private val getMyAnsweredConsultUseCase: GetMyAnsweredConsultUseCase,
     private val logoutUseCase: LogoutUseCase
 ) : ViewModel() {
 
@@ -31,6 +38,7 @@ class MyPageViewModel @Inject constructor(
         loadData()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun loadData() {
         val userId = getCurrentUserIdUseCase()
         if (userId.isNullOrEmpty()) {
@@ -39,27 +47,49 @@ class MyPageViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            combine(
-                getUserUseCase(userId),
-                getMyConsultUseCase(userId)
-            ) { userResult, consultResult ->
+            getUserUseCase(userId).flatMapLatest { userResult ->
                 val user = if (userResult is DataResourceResult.Success) userResult.resultData else null
-                val consults = if (consultResult is DataResourceResult.Success) consultResult.resultData else emptyList()
+                val isPharmacist = user?.userType == UserType.PHARMACIST
+
+                val consultFlow = if (isPharmacist) {
+                    getMyAnsweredConsultUseCase(userId)
+                } else {
+                    getMyConsultUseCase(userId)
+                }
+
+                consultFlow.map { consultResult ->
+                    Pair(userResult, consultResult)
+                }
+            }.collectLatest { (userResult, consultResult) ->
+                val user = if (userResult is DataResourceResult.Success) userResult.resultData else _uiState.value.user
+                val consults = if (consultResult is DataResourceResult.Success) {
+                    consultResult.resultData
+                } else {
+                    _uiState.value.myConsults
+                }
                 val isLoading = userResult is DataResourceResult.Loading || consultResult is DataResourceResult.Loading
                 val errorMsg: UiMessage? = when {
                     userResult is DataResourceResult.Failure -> UiMessage.LoadDataFailed
                     consultResult is DataResourceResult.Failure -> UiMessage.LoadDataFailed
                     else -> null
                 }
+                val isPharmacist = user?.userType == UserType.PHARMACIST
+                val totalCount = consults.size
 
-                MyPageUiState(
+                val countText = if (isPharmacist) {
+                    val completedCount = consults.count { it.status == ConsultStatus.COMPLETED }
+                    if (totalCount > 0) "$completedCount/$totalCount" else null
+                } else {
+                    if (totalCount > 0) "$totalCount" else null
+                }
+
+                _uiState.value = MyPageUiState(
                     isLoading = isLoading,
                     user = user,
                     myConsults = consults,
-                    userMessage = errorMsg
+                    userMessage = errorMsg,
+                    consultHistoryText = countText
                 )
-            }.collect { newState ->
-                _uiState.value = newState
             }
         }
     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/util/UserTypeExtensions.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/util/UserTypeExtensions.kt
@@ -2,6 +2,7 @@ package com.moon.pharm.profile.util
 
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.R
+import com.moon.pharm.component_ui.R as UiR
 
 val UserType.labelRes: Int
     get() = when (this) {
@@ -9,8 +10,8 @@ val UserType.labelRes: Int
         UserType.PHARMACIST -> R.string.signup_type_pharmacist
     }
 
-val UserType.apiValue: String
+val UserType.myPageConsultMenuTitleRes: Int
     get() = when (this) {
-        UserType.GENERAL -> "일반"
-        UserType.PHARMACIST -> "약사"
+        UserType.PHARMACIST -> UiR.string.my_answer_title
+        UserType.GENERAL -> UiR.string.my_consult_title
     }

--- a/features/profile/src/main/res/values/strings.xml
+++ b/features/profile/src/main/res/values/strings.xml
@@ -49,8 +49,7 @@
 
     <!--  마이페이지(mypage)  -->
     <string name="mypage_title">마이페이지</string>
-    <string name="mypage_consult_history">나의 상담 내역</string>
-    <string name="mypage_consult_history_format">나의 상담 내역 (%d)</string>
+    <string name="mypage_consult_history_format">(%s)</string>
     <string name="mypage_menu_medication_record">나의 약 기록</string>
     <string name="mypage_menu_alarm_setting">복용 알림 설정</string>
     <string name="mypage_menu_core_feature">핵심 기능</string>


### PR DESCRIPTION
[domain & data]
- 약사 답변 내역 조회를 위한 GetMyAnsweredConsultUseCase 추가
- 약사 답변 내역을 가져오기 위해 Repository 및 DataSource 수정

[feature: mypage]
- 상담/답변 개수 계산 로직을 Screen에서 ViewModel로 이동
- 약사 회원을 위한 '완료/전체(예: 3/5건)' 카운트 포맷 지원
- 로딩 중 기존 데이터를 유지하여 리스트 깜빡임 현상 수정
- 보조(Secondary) 개수 텍스트 표시를 위해 MyPageMenuSection 업데이트

[feature: consult]
- UserType 확장 프로퍼티(UserTypeExt)를 도입하여 화면 타이틀 및 빈 화면 메시지 분기 로직 개선
- 각 유저 타입별(약사/일반) 독립적인 데이터 흐름 처리를 위해 ViewModel 수정

Close #46