### PR TITLE
feat(home): 홈 화면 더미 데이터 제거 및 실제 유저 닉네임 연동

### DIFF
--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin{
 }
 
 dependencies {
+    implementation(project(":domain"))
     implementation(project(":features:component-ui"))
 
     implementation(libs.androidx.core.ktx)

--- a/features/home/src/main/java/com/moon/pharm/home/screen/HomeMainScreen.kt
+++ b/features/home/src/main/java/com/moon/pharm/home/screen/HomeMainScreen.kt
@@ -25,12 +25,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.moon.pharm.component_ui.R
 import com.moon.pharm.component_ui.component.SectionHeader
@@ -47,12 +50,16 @@ import com.moon.pharm.component_ui.theme.SecondFont
 import com.moon.pharm.component_ui.theme.Secondary
 import com.moon.pharm.component_ui.theme.White
 import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.home.viewmodel.HomeViewModel
 
 @Composable
 fun HomeMainScreen(
-    navController: NavController
+    navController: NavController,
+    viewModel: HomeViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
+    val nickname by viewModel.nickname.collectAsState()
+    val displayName = nickname.ifEmpty { "회원" }
 
     Scaffold(
         topBar = {
@@ -90,7 +97,7 @@ fun HomeMainScreen(
                     .padding(24.dp),
             ) {
                 Text(
-                    text = "ooo님, 건강 챙기세요!",
+                    text = "${displayName}님, 건강 챙기세요!",
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
                     color = OnSurface

--- a/features/home/src/main/java/com/moon/pharm/home/viewmodel/HomeViewModel.kt
+++ b/features/home/src/main/java/com/moon/pharm/home/viewmodel/HomeViewModel.kt
@@ -1,0 +1,40 @@
+package com.moon.pharm.home.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
+import com.moon.pharm.domain.usecase.user.GetNicknameUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
+    private val getNicknameUseCase: GetNicknameUseCase
+) : ViewModel() {
+
+    private val _nickname = MutableStateFlow("")
+    val nickname: StateFlow<String> = _nickname.asStateFlow()
+
+    init {
+        loadUserNickname()
+    }
+
+    private fun loadUserNickname() {
+        viewModelScope.launch {
+            val userId = getCurrentUserIdUseCase()
+
+            if (userId != null) {
+                val fetchedNickname = getNicknameUseCase.getNickname(userId)
+
+                if (fetchedNickname.isNotEmpty()) {
+                    _nickname.value = fetchedNickname
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- HomeViewModel 추가: 유저 닉네임 로드 로직 구현
- GetCurrentUserIdUseCase 및 GetNicknameUseCase 적용
- HomeMainScreen에 ViewModel 주입 및 StateFlow 구독 처리
- 더미 텍스트("ooo님")를 실제 로드된 닉네임으로 교체

Close #56