### PR TITLE
fix(consult): 상담 게시판 비공개 글 잠금 로직 적용 및 DTO 매핑 해결

### DIFF
--- a/data/src/main/java/com/moon/pharm/data/datasource/remote/dto/ConsultItemDTO.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/remote/dto/ConsultItemDTO.kt
@@ -3,6 +3,7 @@ package com.moon.pharm.data.datasource.remote.dto
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentId
 import com.google.firebase.firestore.IgnoreExtraProperties
+import com.google.firebase.firestore.PropertyName
 import com.google.firebase.firestore.ServerTimestamp
 import com.moon.pharm.data.common.EMPTY_STRING
 import com.moon.pharm.domain.model.consult.ConsultStatus
@@ -18,7 +19,11 @@ data class ConsultItemDTO(
     var title: String = EMPTY_STRING,
     var content: String = EMPTY_STRING,
     var status: String = ConsultStatus.WAITING.name,
-    val isPublic: Boolean = true,
+
+    @get:PropertyName("public")
+    @set:PropertyName("public")
+    var isPublic: Boolean? = null,
+
     var images: List<ConsultImageDTO>? = null,
 
     @ServerTimestamp

--- a/data/src/main/java/com/moon/pharm/data/mapper/ConsultMapper.kt
+++ b/data/src/main/java/com/moon/pharm/data/mapper/ConsultMapper.kt
@@ -22,7 +22,7 @@ fun ConsultItemDTO.toDomain(): ConsultItem {
         } catch (e: Exception) {
             ConsultStatus.WAITING
         },
-        isPublic = this.isPublic,
+        isPublic = this.isPublic?: false,
         images = this.images?.map { ConsultImage(it.imageName, it.imageUrl) } ?: emptyList(),
         createdAt = this.createdAt?.toDate()?.time ?: 0L,
         answer = this.answer?.toDomain()

--- a/domain/src/main/java/com/moon/pharm/domain/model/consult/ConsultItem.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/model/consult/ConsultItem.kt
@@ -8,7 +8,7 @@ data class ConsultItem(
     val title: String,
     val content: String,
     val status: ConsultStatus,
-    val isPublic: Boolean = true,
+    val isPublic: Boolean,
     val createdAt: Long,
     val images: List<ConsultImage> = emptyList(),
     val answer: ConsultAnswer? = null

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultItemsUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultItemsUseCase.kt
@@ -3,49 +3,36 @@ package com.moon.pharm.domain.usecase.consult
 import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.repository.ConsultRepository
 import com.moon.pharm.domain.result.DataResourceResult
-import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.moon.pharm.domain.usecase.user.GetNicknameUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetConsultItemsUseCase @Inject constructor(
     private val repository: ConsultRepository,
-    private val getNicknameUseCase: GetNicknameUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getNicknameUseCase: GetNicknameUseCase
 ) {
-    operator fun invoke(): Flow<DataResourceResult<List<ConsultItem>>> = flow {
-        emit(DataResourceResult.Loading)
+    operator fun invoke(): Flow<DataResourceResult<List<ConsultItem>>> {
+        return repository.getConsultItems()
+            .map { result ->
+                if (result is DataResourceResult.Success) {
+                    val rawList = result.resultData
 
-        val currentUserId = getCurrentUserIdUseCase()
+                    val distinctUserIds = rawList.map { it.userId }.distinct()
 
-        val listResult = repository.getConsultItems()
-            .filter { it !is DataResourceResult.Loading }
-            .first()
+                    val nicknameMap = mutableMapOf<String, String>()
+                    distinctUserIds.forEach { userId ->
+                        nicknameMap[userId] = getNicknameUseCase.getNickname(userId)
+                    }
 
-        if (listResult is DataResourceResult.Success) {
-            val rawList = listResult.resultData
-            val filteredList = rawList.filter { item ->
-                item.isPublic || (currentUserId != null && item.userId == currentUserId)
+                    val enrichedList = rawList.map { item ->
+                        item.copy(nickName = nicknameMap[item.userId] ?: "")
+                    }
+
+                    DataResourceResult.Success(enrichedList)
+                } else {
+                    result
+                }
             }
-
-            val distinctUserIds = filteredList.map { it.userId }.distinct()
-            val nicknameMap = mutableMapOf<String, String>()
-
-            distinctUserIds.forEach { userId ->
-                nicknameMap[userId] = getNicknameUseCase.getNickname(userId)
-            }
-
-            val enrichedList = filteredList.map { item ->
-                item.copy(nickName = nicknameMap[item.userId] ?: "")
-            }
-
-            emit(DataResourceResult.Success(enrichedList))
-
-        } else if (listResult is DataResourceResult.Failure) {
-            emit(DataResourceResult.Failure(listResult.exception))
-        }
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultContent.kt
@@ -14,8 +14,10 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 fun ConsultContent(
     selectedTab: ConsultPrimaryTab,
     currentList: List<ConsultItem>,
+    currentUserId: String?,
+    isPharmacist: Boolean,
     onTabSelected: (ConsultPrimaryTab) -> Unit,
-    onItemClick: (String) -> Unit
+    onItemClick: (ConsultItem) -> Unit
 ) {
     val tabTitles = ConsultPrimaryTab.entries.map { it.title }
 
@@ -30,7 +32,11 @@ fun ConsultContent(
             onTabSelected = { index -> onTabSelected(ConsultPrimaryTab.fromIndex(index)) })
 
         ConsultList(
-            currentList = currentList, onItemClick = onItemClick, modifier = Modifier.weight(1f)
+            currentList = currentList,
+            currentUserId = currentUserId,
+            isPharmacist = isPharmacist,
+            onItemClick = onItemClick,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
@@ -7,13 +7,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -24,12 +29,23 @@ import com.moon.pharm.component_ui.theme.White
 import com.moon.pharm.component_ui.theme.primaryLight
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
+import com.moon.pharm.consult.R
 import com.moon.pharm.consult.mapper.toBackgroundColor
 import com.moon.pharm.consult.mapper.toTextColor
 import com.moon.pharm.domain.model.consult.ConsultItem
 
 @Composable
-fun ConsultItemCard(item: ConsultItem, onClick: () -> Unit) {
+fun ConsultItemCard(
+    item: ConsultItem,
+    currentUserId: String?,
+    isPharmacist: Boolean,
+    onClick: () -> Unit
+) {
+    val isSecret = !item.isPublic
+    val isOwner = !currentUserId.isNullOrBlank() && item.userId == currentUserId
+    val isAssignedPharmacist = isPharmacist && item.pharmacistId == currentUserId
+    val hasPermission = !isSecret || isOwner || isAssignedPharmacist
+
     ElevatedCard(
         colors = CardDefaults.elevatedCardColors(containerColor = White),
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
@@ -45,16 +61,29 @@ fun ConsultItemCard(item: ConsultItem, onClick: () -> Unit) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = item.title,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = primaryLight,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    lineHeight = 20.sp
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (isSecret) {
+                        Icon(
+                            imageVector = Icons.Default.Lock,
+                            contentDescription = stringResource(R.string.consult_secret_icon_desc),
+                            tint = if (hasPermission) primaryLight else SecondFont,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
+
+                    Text(
+                        text = if (hasPermission) item.title else stringResource(R.string.consult_secret_hidden_title),
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (hasPermission) primaryLight else SecondFont,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        lineHeight = 20.sp
+                    )
+                }
                 Spacer(modifier = Modifier.height(6.dp))
+
                 Text(
                     text = "${item.nickName} • ${item.createdAt.toDisplayDateTimeString()}",
                     fontSize = 12.sp,

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultList.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultList.kt
@@ -25,7 +25,11 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 
 @Composable
 fun ConsultList(
-    currentList: List<ConsultItem>, onItemClick: (String) -> Unit, modifier: Modifier = Modifier
+    currentList: List<ConsultItem>,
+    currentUserId: String?,
+    isPharmacist: Boolean,
+    onItemClick: (ConsultItem) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     if (currentList.isEmpty()) {
         Box(
@@ -60,7 +64,11 @@ fun ConsultList(
             items(
                 items = currentList, key = { it.id }) { item ->
                 ConsultItemCard(
-                    item = item, onClick = { onItemClick(item.id) })
+                    item = item,
+                    currentUserId = currentUserId,
+                    isPharmacist = isPharmacist,
+                    onClick = { onItemClick(item) }
+                )
             }
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultPrivacyToggle.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultPrivacyToggle.kt
@@ -23,6 +23,8 @@ fun ConsultPrivacyToggle(
     isPublic: Boolean,
     onVisibilityChange: (Boolean) -> Unit
 ) {
+    val isSecretMode = !isPublic
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,8 +47,10 @@ fun ConsultPrivacyToggle(
             )
         }
         CustomSwitch(
-            checked = isPublic,
-            onCheckedChange = onVisibilityChange
+            checked = isSecretMode,
+            onCheckedChange = { isChecked ->
+                onVisibilityChange(!isChecked)
+            }
         )
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultListContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultListContent.kt
@@ -13,6 +13,8 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 @Composable
 fun MyConsultListContent(
     items: List<ConsultItem>,
+    currentUserId: String?,
+    isPharmacist: Boolean,
     onItemClick: (String) -> Unit
 ) {
     LazyColumn(
@@ -23,6 +25,8 @@ fun MyConsultListContent(
         items(items = items, key = { it.id }) { item ->
             ConsultItemCard(
                 item = item,
+                currentUserId = currentUserId,
+                isPharmacist = isPharmacist,
                 onClick = { onItemClick(item.id) }
             )
         }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/my/MyConsultListScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/my/MyConsultListScreen.kt
@@ -102,6 +102,8 @@ fun MyConsultListScreen(
                 else -> {
                     MyConsultListContent(
                         items = uiState.myConsults,
+                        currentUserId = uiState.currentUserId,
+                        isPharmacist = uiState.isPharmacist,
                         onItemClick = onItemClick
                     )
                 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultListUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultListUiState.kt
@@ -8,5 +8,7 @@ data class ConsultListUiState(
     val isLoading: Boolean = false,
     val userMessage: UiMessage? = null,
     val consultList: List<ConsultItem> = emptyList(),
-    val selectedTab: ConsultPrimaryTab = ConsultPrimaryTab.LATEST
+    val selectedTab: ConsultPrimaryTab = ConsultPrimaryTab.LATEST,
+    val currentUserId: String? = null,
+    val isPharmacist: Boolean = false
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultListViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultListViewModel.kt
@@ -4,19 +4,25 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moon.pharm.component_ui.common.UiMessage
 import com.moon.pharm.consult.model.ConsultPrimaryTab
+import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.domain.result.DataResourceResult
+import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.moon.pharm.domain.usecase.consult.ConsultUseCases
+import com.moon.pharm.domain.usecase.user.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ConsultListViewModel @Inject constructor(
-    private val consultUseCases: ConsultUseCases
+    private val consultUseCases: ConsultUseCases,
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
+    private val getUserUseCase: GetUserUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ConsultListUiState())
     val uiState = _uiState.asStateFlow()
@@ -35,6 +41,20 @@ class ConsultListViewModel @Inject constructor(
 
     fun fetchConsultList() {
         viewModelScope.launch {
+            val userId = getCurrentUserIdUseCase()
+            var isPharmacist = false
+
+            if (userId != null) {
+                val userResult = getUserUseCase(userId).first()
+                if (userResult is DataResourceResult.Success) {
+                    isPharmacist = userResult.resultData.userType == UserType.PHARMACIST
+                }
+            }
+
+            _uiState.update {
+                it.copy(currentUserId = userId, isPharmacist = isPharmacist)
+            }
+
             consultUseCases.getConsultList().collectLatest { result ->
                 _uiState.update { state ->
                     when (result) {
@@ -43,7 +63,6 @@ class ConsultListViewModel @Inject constructor(
                             isLoading = false,
                             consultList = result.resultData
                         )
-
                         is DataResourceResult.Failure -> state.copy(
                             isLoading = false,
                             userMessage = UiMessage.LoadDataFailed

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListUiState.kt
@@ -7,5 +7,6 @@ data class MyConsultListUiState(
     val isLoading: Boolean = false,
     val userMessage: UiMessage? = null,
     val myConsults: List<ConsultItem> = emptyList(),
-    val isPharmacist: Boolean = false
+    val isPharmacist: Boolean = false,
+    val currentUserId: String? = null
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/MyConsultListViewModel.kt
@@ -56,6 +56,10 @@ class MyConsultListViewModel @Inject constructor(
                 false
             }
 
+            _uiState.update {
+                it.copy(currentUserId = userId, isPharmacist = isPharmacist)
+            }
+
             val consultFlow = if (isPharmacist) {
                 getMyAnsweredConsultUseCase(userId)
             } else {
@@ -70,12 +74,14 @@ class MyConsultListViewModel @Inject constructor(
                             isLoading = false,
                             myConsults = result.resultData,
                             userMessage = null,
-                            isPharmacist = isPharmacist
+                            isPharmacist = isPharmacist,
+                            currentUserId = userId
                         )
                         is DataResourceResult.Failure -> state.copy(
                             isLoading = false,
                             userMessage = if (state.myConsults.isEmpty()) UiMessage.LoadDataFailed else null,
-                            isPharmacist = isPharmacist
+                            isPharmacist = isPharmacist,
+                            currentUserId = userId
                         )
                     }
                 }

--- a/features/consult/src/main/res/values/strings.xml
+++ b/features/consult/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="my_consult_empty">작성한 상담 내역이 없습니다.</string>
     <string name="my_answer_empty">작성한 답변 내역이 없습니다.</string>
 
+    <string name="consult_secret_icon_desc">비공개</string>
+    <string name="consult_secret_hidden_title">비공개 상담입니다.</string>
+
     <!--  WriteScreen  -->
     <string name="consult_write_placeholder_title">제목을 입력해주세요</string>
     <string name="consult_write_placeholder_content">구체적인 증상, 복용 중인 다른 약물 정보 등을 자세히 작성해주세요.</string>


### PR DESCRIPTION
[feat: consult]
- 비공개 상담글 UI 처리 로직 적용: 타인의 비공개 글을 리스트에서 제외하지 않고 '비공개 상담입니다' 문구와 잠금 아이콘으로 표시
- `MyConsultListViewModel`에 유저 권한 상태(User ID, 약사 여부) 주입 로직 추가 (공통 컴포넌트 `ConsultItemCard`의 권한 체크 지원을 위함)

[fix: consult]
- Firestore DTO 매핑 오류 수정: `isPublic` 필드에 `@get:PropertyName("public")` 및 `@set:PropertyName`을 명시하여 직렬화 문제 해결
- 도메인 레이어 로직 개선: `GetConsultItemsUseCase` 내부의 임의 필터링 제거 및 Flow 스트림 유지로 실시간 데이터 반영, 미사용 의존성 제거

Close #62