### PR TITLE
refactor: 로그인 전환 시 하단바 노출 문제 수정 및 네비게이션 구조 개편

### DIFF
--- a/app/src/main/java/com/moon/pharm/ui/screen/EntryPointScreen.kt
+++ b/app/src/main/java/com/moon/pharm/ui/screen/EntryPointScreen.kt
@@ -1,107 +1,34 @@
 package com.moon.pharm.ui.screen
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.moon.pharm.component_ui.component.bar.PharmBottomBar
-import com.moon.pharm.component_ui.model.BottomBarUiModel
 import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
-import com.moon.pharm.consult.navigation.consultNavGraph
-import com.moon.pharm.home.navigation.homeNavGraph
-import com.moon.pharm.prescription.navigation.prescriptionNavGraph
-import com.moon.pharm.profile.navigation.profileNavGraph
-import com.moon.pharm.ui.navigation.BottomAppBarItem
-import kotlinx.coroutines.flow.collectLatest
+import com.moon.pharm.profile.navigation.authNavGraph
 
 @Composable
 fun EntryPointScreen(
     viewModel: MainViewModel = hiltViewModel()
 ) {
-    val navController = rememberNavController()
+    val rootNavController = rememberNavController()
 
-    LaunchedEffect(Unit) {
-        viewModel.navigationEvent.collectLatest { route ->
-            if (route == "MedicationScreen") {
-                navController.navigate(ContentNavigationRoute.MedicationTab) {
-                    popUpTo(navController.graph.findStartDestination().id) {
-                        saveState = true
+    NavHost(
+        navController = rootNavController,
+        startDestination = ContentNavigationRoute.LoginScreen
+    ) {
+        authNavGraph(rootNavController)
+        composable<ContentNavigationRoute.MainBase> {
+            MainScreen(
+                viewModel = viewModel,
+                onLogout = {
+                    rootNavController.navigate(ContentNavigationRoute.LoginScreen) {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
                     }
-                    launchSingleTop = true
-                    restoreState = true
                 }
-            }
-        }
-    }
-
-    val bottomAppBarItems = remember { BottomAppBarItem.fetchBottomAppBarItems() }
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
-
-    val isFullScreen = currentRoute?.let { route ->
-        route.contains("SignUpScreen") ||
-                route.contains("LoginScreen") ||
-                route.contains("PrescriptionCapture")
-    } == true
-
-    var isMapMode by remember { mutableStateOf(false) }
-    val shouldShowBars = !isFullScreen && !isMapMode
-
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        contentWindowInsets = WindowInsets.navigationBars,
-        bottomBar = {
-            if (shouldShowBars) {
-                val uiModels = bottomAppBarItems.map { navItem ->
-                    BottomBarUiModel(
-                        tabName = navItem.tabName,
-                        icon = navItem.icon,
-                        onClick = {
-                            navController.navigate(navItem.destination) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
-                                }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        }
-                    )
-                }
-                PharmBottomBar(items = uiModels, currentRoute = currentRoute)
-            }
-        }
-    ) { innerPadding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = innerPadding.calculateBottomPadding())
-                .consumeWindowInsets(innerPadding)
-        ) {
-            NavHost(
-                navController = navController,
-                startDestination = ContentNavigationRoute.LoginScreen,
-                modifier = Modifier.fillMaxSize()
-            ) {
-                homeNavGraph(navController)
-                consultNavGraph(navController, onMapModeChanged = { isMapVisible -> isMapMode = isMapVisible })
-                profileNavGraph(navController)
-                prescriptionNavGraph(navController)
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/com/moon/pharm/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/moon/pharm/ui/screen/MainScreen.kt
@@ -1,0 +1,103 @@
+package com.moon.pharm.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.moon.pharm.component_ui.component.bar.PharmBottomBar
+import com.moon.pharm.component_ui.model.BottomBarUiModel
+import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
+import com.moon.pharm.consult.navigation.consultNavGraph
+import com.moon.pharm.home.navigation.homeNavGraph
+import com.moon.pharm.prescription.navigation.prescriptionNavGraph
+import com.moon.pharm.profile.navigation.profileNavGraph
+import com.moon.pharm.ui.navigation.BottomAppBarItem
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun MainScreen(
+    viewModel: MainViewModel,
+    onLogout: () -> Unit
+) {
+    val mainNavController = rememberNavController()
+
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collectLatest { route ->
+            if (route == "MedicationScreen") {
+                mainNavController.navigate(ContentNavigationRoute.MedicationTab) {
+                    popUpTo(mainNavController.graph.findStartDestination().id) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
+    }
+
+    val bottomAppBarItems = remember { BottomAppBarItem.fetchBottomAppBarItems() }
+    val navBackStackEntry by mainNavController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    val isFullScreen = currentRoute?.contains("PrescriptionCapture") == true
+
+    var isMapMode by remember { mutableStateOf(false) }
+    val shouldShowBars = !isFullScreen && !isMapMode
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets.navigationBars,
+        bottomBar = {
+            if (shouldShowBars) {
+                val uiModels = bottomAppBarItems.map { navItem ->
+                    BottomBarUiModel(
+                        tabName = navItem.tabName,
+                        icon = navItem.icon,
+                        onClick = {
+                            mainNavController.navigate(navItem.destination) {
+                                popUpTo(mainNavController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    )
+                }
+                PharmBottomBar(items = uiModels, currentRoute = currentRoute)
+            }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = innerPadding.calculateBottomPadding())
+                .consumeWindowInsets(innerPadding)
+        ) {
+            NavHost(
+                navController = mainNavController,
+                startDestination = ContentNavigationRoute.HomeTab,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                homeNavGraph(mainNavController)
+                consultNavGraph(mainNavController, onMapModeChanged = { isMapVisible -> isMapMode = isMapVisible })
+                profileNavGraph(mainNavController, onLogout = onLogout)
+                prescriptionNavGraph(mainNavController)
+            }
+        }
+    }
+}

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/navigation/ContentNavRoute.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/navigation/ContentNavRoute.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface ContentNavigationRoute : PharmNavigation {
     @Serializable
+    data object MainBase : ContentNavigationRoute
+    @Serializable
     data object LoginScreen : ContentNavigationRoute
     @Serializable
     data object SignUpScreen : ContentNavigationRoute

--- a/features/profile/src/main/java/com/moon/pharm/profile/navigation/ProfileNavGraphBuilder.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/navigation/ProfileNavGraphBuilder.kt
@@ -18,34 +18,63 @@ import com.moon.pharm.profile.medication.viewmodel.MedicationViewModel
 import com.moon.pharm.profile.mypage.screen.MyPageRoute
 import kotlin.reflect.typeOf
 
-fun NavGraphBuilder.profileNavGraph(navController: NavController) {
-
+fun NavGraphBuilder.authNavGraph(rootNavController: NavController) {
     composable<ContentNavigationRoute.LoginScreen> {
         val viewModel: LoginViewModel = hiltViewModel()
         LoginScreen(
             viewModel = viewModel,
+            onNavigateToSignUp = {
+                rootNavController.navigate(ContentNavigationRoute.SignUpScreen)
+            },
             onNavigateToHome = {
-                navController.navigate(ContentNavigationRoute.HomeTab) {
+                rootNavController.navigate(ContentNavigationRoute.MainBase) {
                     popUpTo(ContentNavigationRoute.LoginScreen) { inclusive = true }
                 }
-            },
-            onNavigateToSignUp = {
-                navController.navigate(ContentNavigationRoute.SignUpScreen)
             }
         )
     }
 
-    composable<ContentNavigationRoute.SignUpScreen>{
+    composable<ContentNavigationRoute.SignUpScreen> {
         val viewModel: SignUpViewModel = hiltViewModel()
         SignUpScreen(
             viewModel = viewModel,
             onNavigateToHome = {
-                navController.navigate(ContentNavigationRoute.HomeTab) {
+                rootNavController.navigate(ContentNavigationRoute.MainBase) {
                     popUpTo(ContentNavigationRoute.SignUpScreen) { inclusive = true }
                 }
             }
         )
     }
+}
+
+fun NavGraphBuilder.profileNavGraph(navController: NavController, onLogout: () -> Unit) {
+
+//    composable<ContentNavigationRoute.LoginScreen> {
+//        val viewModel: LoginViewModel = hiltViewModel()
+//        LoginScreen(
+//            viewModel = viewModel,
+//            onNavigateToHome = {
+//                navController.navigate(ContentNavigationRoute.HomeTab) {
+//                    popUpTo(ContentNavigationRoute.LoginScreen) { inclusive = true }
+//                }
+//            },
+//            onNavigateToSignUp = {
+//                navController.navigate(ContentNavigationRoute.SignUpScreen)
+//            }
+//        )
+//    }
+//
+//    composable<ContentNavigationRoute.SignUpScreen>{
+//        val viewModel: SignUpViewModel = hiltViewModel()
+//        SignUpScreen(
+//            viewModel = viewModel,
+//            onNavigateToHome = {
+//                navController.navigate(ContentNavigationRoute.HomeTab) {
+//                    popUpTo(ContentNavigationRoute.SignUpScreen) { inclusive = true }
+//                }
+//            }
+//        )
+//    }
 
     composable<ContentNavigationRoute.ProfileTab> {
         MyPageRoute(
@@ -56,10 +85,7 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController) {
                 navController.navigate(ContentNavigationRoute.MedicationTabHistoryScreen)
             },
             onNavigateToLogin = {
-                navController.navigate(ContentNavigationRoute.LoginScreen) {
-                    popUpTo(0) { inclusive = true }
-                    launchSingleTop = true
-                }
+                onLogout()
             }
         )
     }


### PR DESCRIPTION
- Login/SignUp 화면을 Root NavHost로 분리하여 하단바 나타나는 문제 해결
- 하단바와 내부 탭 기능을 캡슐화한 MainScreen 컴포저블 신설
- 모듈 간 결합도 완화를 위해 auth 및 profile 콘텐츠 네비게이션 그래프 분리
- 로그아웃 처리를 위한 상위 콜백 로직 구현

Close #65