### PR TITLE
fix(medication): 약물 타입 선택기 동작 오류 수정

### DIFF
--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationViewModel.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationViewModel.kt
@@ -79,7 +79,18 @@ class MedicationViewModel @Inject constructor(
     // region 2. Event Handler
     fun onEvent(event: MedicationUiEvent) {
         when (event) {
-            is MedicationUiEvent.UpdateType -> updateForm(event.index) { it.copy(selectedType = event.type) }
+            is MedicationUiEvent.UpdateType -> {
+                if (event.index == -1) {
+                    _uiState.update { state ->
+                        val newForms = state.medicationForms.map {
+                            it.copy(selectedType = event.type)
+                        }
+                        state.copy(medicationForms = newForms)
+                    }
+                } else {
+                    updateForm(event.index) { it.copy(selectedType = event.type) }
+                }
+            }
             is MedicationUiEvent.UpdateName -> updateForm(event.index) { it.copy(medicationName = event.name) }
             is MedicationUiEvent.UpdateDosage -> {
                 if (event.index == -1) {


### PR DESCRIPTION
- MedicationTypeSelector 클릭 시 ViewModel에 index -1(일괄 적용) 이벤트가 전달되나, ViewModel에서 해당 로직이 누락되어 UI가 갱신되지 않는 문제 해결
- UpdateType 이벤트에 전체 약물 리스트 업데이트 로직 추가

Close #68