### PR TITLE
chore(release): 마이페이지 닉네임 변경 시 상담 내역 리스트 즉시 동기화

### DIFF
--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageViewModel.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/viewmodel/MyPageViewModel.kt
@@ -54,7 +54,12 @@ class MyPageViewModel @Inject constructor(
                     userMessage = UiMessage.LoadDataFailed
                 )
             } else {
-                _uiState.value = _uiState.value.copy(isLoading = false)
+                val updatedUser = currentUser.copy(nickName = newNickname)
+
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    user = updatedUser
+                )
             }
         }
     }


### PR DESCRIPTION
## 작업 요약
- 마이페이지 닉네임 변경 시 '나의 상담 내역' 리스트가 즉시 갱신되지 않는 버그 수정

---

## 주요 변경 사항
- ViewModel의 유저 데이터 수집을 일회성(`first`)에서 지속 구독(`collectLatest`)으로 변경
- 중첩 `collectLatest` 패턴을 적용하여 유저 정보 변경 시 상담 목록 조회를 자동 재시작하도록 개선
- 일반 유저의 상담 리스트 아이템 작성자 이름을 최신 닉네임으로 매핑하는 로직 추가

---

## 관련 이슈
- Close #74 