### PR TITLE
chore(release): 알림 진입 시 자동 로그아웃 문제 해결 및 네비게이션 타입 안정화

### DIFF
--- a/app/src/main/java/com/moon/pharm/alarm/AlarmNotificationServiceImpl.kt
+++ b/app/src/main/java/com/moon/pharm/alarm/AlarmNotificationServiceImpl.kt
@@ -35,7 +35,7 @@ class AlarmNotificationServiceImpl @Inject constructor(
         createNotificationChannel(notificationManager)
 
         val intent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(AlarmConstants.KEY_IS_FROM_ALARM, true)
             putExtra(AlarmConstants.KEY_TARGET_FRAGMENT, AlarmConstants.FRAGMENT_MEDICATION)
         }

--- a/app/src/main/java/com/moon/pharm/ui/screen/EntryPointScreen.kt
+++ b/app/src/main/java/com/moon/pharm/ui/screen/EntryPointScreen.kt
@@ -1,34 +1,49 @@
 package com.moon.pharm.ui.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
 import com.moon.pharm.profile.navigation.authNavGraph
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun EntryPointScreen(
     viewModel: MainViewModel = hiltViewModel()
 ) {
     val rootNavController = rememberNavController()
+    val startDestination by viewModel.startDestination.collectAsStateWithLifecycle()
 
-    NavHost(
-        navController = rootNavController,
-        startDestination = ContentNavigationRoute.LoginScreen
-    ) {
-        authNavGraph(rootNavController)
-        composable<ContentNavigationRoute.MainBase> {
-            MainScreen(
-                viewModel = viewModel,
-                onLogout = {
-                    rootNavController.navigate(ContentNavigationRoute.LoginScreen) {
-                        popUpTo(0) { inclusive = true }
-                        launchSingleTop = true
+    LaunchedEffect(true) {
+        viewModel.navigationEvent.collectLatest { route ->
+            rootNavController.navigate(route) {
+                launchSingleTop = true
+            }
+        }
+    }
+
+    if (startDestination != null) {
+        NavHost(
+            navController = rootNavController,
+            startDestination = startDestination!!
+        ) {
+            authNavGraph(rootNavController)
+            composable<ContentNavigationRoute.MainBase> {
+                MainScreen(
+                    viewModel = viewModel,
+                    onLogout = {
+                        rootNavController.navigate(ContentNavigationRoute.LoginScreen) {
+                            popUpTo(0) { inclusive = true }
+                            launchSingleTop = true
+                        }
                     }
-                }
-            )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/moon/pharm/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/moon/pharm/ui/screen/MainScreen.kt
@@ -37,7 +37,7 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.collectLatest { route ->
-            if (route == "MedicationScreen") {
+            if (route is ContentNavigationRoute.MedicationTab) {
                 mainNavController.navigate(ContentNavigationRoute.MedicationTab) {
                     popUpTo(mainNavController.graph.findStartDestination().id) {
                         saveState = true

--- a/app/src/main/java/com/moon/pharm/ui/screen/MainViewModel.kt
+++ b/app/src/main/java/com/moon/pharm/ui/screen/MainViewModel.kt
@@ -2,6 +2,8 @@ package com.moon.pharm.ui.screen
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
+import com.moon.pharm.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.moon.pharm.domain.usecase.user.SyncFcmTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -14,21 +16,39 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val syncFcmTokenUseCase: SyncFcmTokenUseCase
+    private val syncFcmTokenUseCase: SyncFcmTokenUseCase,
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
 ) : ViewModel() {
 
     private val _isSplashLoading = MutableStateFlow(true)
     val isSplashLoading = _isSplashLoading.asStateFlow()
 
-    private val _navigationEvent = Channel<String>(Channel.BUFFERED)
+    private val _startDestination = MutableStateFlow<ContentNavigationRoute?>(null)
+    val startDestination = _startDestination.asStateFlow()
+
+    private val _navigationEvent = Channel<ContentNavigationRoute>(Channel.BUFFERED)
     val navigationEvent = _navigationEvent.receiveAsFlow()
 
     init {
+        checkLoginStatus()
+        syncToken()
+    }
+
+    private fun checkLoginStatus() {
         viewModelScope.launch {
-            delay(1000)
+            val userId = getCurrentUserIdUseCase()
+
+            if (userId != null) {
+                _startDestination.value = ContentNavigationRoute.MainBase
+            } else {
+                _startDestination.value = ContentNavigationRoute.LoginScreen
+            }
+            delay(500)
             _isSplashLoading.value = false
         }
+    }
 
+    private fun syncToken() {
         viewModelScope.launch {
             try {
                 syncFcmTokenUseCase()
@@ -39,18 +59,12 @@ class MainViewModel @Inject constructor(
     }
 
     fun refreshFcmToken() {
-        viewModelScope.launch {
-            try {
-                syncFcmTokenUseCase()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
+        syncToken()
     }
 
     fun moveToMedicationTab() {
         viewModelScope.launch {
-            _navigationEvent.send("MedicationScreen")
+            _navigationEvent.send(ContentNavigationRoute.MedicationTab)
         }
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/navigation/ProfileNavGraphBuilder.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/navigation/ProfileNavGraphBuilder.kt
@@ -48,34 +48,6 @@ fun NavGraphBuilder.authNavGraph(rootNavController: NavController) {
 }
 
 fun NavGraphBuilder.profileNavGraph(navController: NavController, onLogout: () -> Unit) {
-
-//    composable<ContentNavigationRoute.LoginScreen> {
-//        val viewModel: LoginViewModel = hiltViewModel()
-//        LoginScreen(
-//            viewModel = viewModel,
-//            onNavigateToHome = {
-//                navController.navigate(ContentNavigationRoute.HomeTab) {
-//                    popUpTo(ContentNavigationRoute.LoginScreen) { inclusive = true }
-//                }
-//            },
-//            onNavigateToSignUp = {
-//                navController.navigate(ContentNavigationRoute.SignUpScreen)
-//            }
-//        )
-//    }
-//
-//    composable<ContentNavigationRoute.SignUpScreen>{
-//        val viewModel: SignUpViewModel = hiltViewModel()
-//        SignUpScreen(
-//            viewModel = viewModel,
-//            onNavigateToHome = {
-//                navController.navigate(ContentNavigationRoute.HomeTab) {
-//                    popUpTo(ContentNavigationRoute.SignUpScreen) { inclusive = true }
-//                }
-//            }
-//        )
-//    }
-
     composable<ContentNavigationRoute.ProfileTab> {
         MyPageRoute(
             onNavigateToMyConsultation = {


### PR DESCRIPTION
## 작업 요약
- 앱 초기 진입 시 로그인 상태를 확인하여 알림 클릭 시 발생하던 자동 로그아웃 문제 해결
- 네비게이션 이벤트 처리의 타입 안정성을 확보하고 스플래시 화면 로직을 개선하여 앱의 안정성 강화

---

## 주연 변경사항
### 1. 앱 초기 진입(EntryPoint) 로직 개선
- 앱 실행 시 `GetCurrentUserIdUseCase`로 로그인 상태를 확인하도록 수정
- `startDestination`을 동적으로 설정하여 로그인된 유저는 즉시 `MainScreen`으로 진입하도록 변경 (알림 클릭 시 로그아웃 현상 해결)

---

### 2. 네비게이션 이벤트 타입 오류 수정 (Type Mismatch)
- `MainViewModel`의 `_navigationEvent` 채널 타입을 `String`에서 `ContentNavigationRoute`로 변경
- `moveToMedicationTab()` 호출 시 안전한 객체 타입 전달 및 `MainScreen` 수신 로직 동기화

---

### 3. 스플래시 로딩 상태 연동
- 로그인 체크가 완료될 때까지 스플래시 화면을 유지하여 화면 깜빡임 방지

---

## 관련 이슈
- Close #76 