### PR TITLE
refactor(component-ui): 공통 UI 리컴포지션 최적화 및 파라미터 구조 개선

### DIFF
--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmBottomBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmBottomBar.kt
@@ -17,11 +17,12 @@ import com.moon.pharm.component_ui.theme.backgroundLight
 @Composable
 fun PharmBottomBar(
     items: List<BottomBarUiModel>,
-    currentRoute: String?
+    currentRoute: String?,
+    modifier: Modifier = Modifier
 ) {
     NavigationBar (
         containerColor = backgroundLight,
-        modifier = Modifier.shadow(elevation = 10.dp)
+        modifier = modifier.shadow(elevation = 10.dp)
     ){
         items.forEach { item ->
             val isSelected = item.tabName == currentRoute

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTopBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTopBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
@@ -32,8 +33,7 @@ import com.moon.pharm.component_ui.theme.Primary
 import com.moon.pharm.component_ui.theme.backgroundLight
 
 /**
- * 앱 표준 상단바.
- * ([TopBarData]를 통해 UI 구성)
+ * 앱 표준 상단바
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,10 +41,12 @@ fun PharmTopBar(
     data: TopBarData,
     modifier: Modifier = Modifier
 ) {
-    val titleContent: @Composable () -> Unit = if (data.isLogoTitle) {
-        { PharmLogoTitle() }
-    } else {
-        { PharmTextTitle(title = data.title) }
+    val titleContent: @Composable () -> Unit = remember(data.isLogoTitle, data.title) {
+        if (data.isLogoTitle) {
+            { PharmLogoTitle() }
+        } else {
+            { PharmTextTitle(title = data.title) }
+        }
     }
 
     CenterAlignedTopAppBar(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/DateSettingCard.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/DateSettingCard.kt
@@ -28,9 +28,9 @@ import com.moon.pharm.component_ui.util.clickableSingle
 fun DateSettingCard(
     placeholder: String,
     value: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    showCalendarIcon: Boolean = false,
-    onClick: () -> Unit
+    showCalendarIcon: Boolean = false
 ) {
     Box(
         modifier = modifier

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/TimeSettingCard.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/TimeSettingCard.kt
@@ -30,10 +30,11 @@ import com.moon.pharm.component_ui.util.clickableSingle
 @Composable
 fun TimeSettingCard(
     time: String?,
-    onTimeClick: () -> Unit
+    onTimeClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .background(White, RoundedCornerShape(10.dp))
             .border(0.5.dp, tertiaryLight, RoundedCornerShape(10.dp))

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/chip/FilterChip.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/chip/FilterChip.kt
@@ -24,10 +24,11 @@ import com.moon.pharm.component_ui.util.clickableSingle
 fun FilterChip(
     text: String,
     isSelected: Boolean,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .height(32.dp)
             .background(if (isSelected) Primary else White, RoundedCornerShape(10.dp))
             .border(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/DatePickerModal.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/DatePickerModal.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -21,10 +22,12 @@ import com.moon.pharm.component_ui.theme.tertiaryContainerLight
 fun DatePickerModal(
     state: DatePickerState,
     onDateSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     DatePickerDialog(
         onDismissRequest = onDismiss,
+        modifier = modifier,
         confirmButton = {
             TextButton(onClick = {
                 onDateSelected(state.selectedDateMillis)

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmInfoDialog.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmInfoDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.theme.Black
@@ -11,10 +12,14 @@ import com.moon.pharm.component_ui.theme.White
 
 @Composable
 fun PharmInfoDialog(
-    title: String, content: String, onDismiss: () -> Unit
+    title: String,
+    content: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        modifier = modifier,
         title = { Text(text = title, fontWeight = FontWeight.Bold, fontSize = 16.sp) },
         text = { Text(text = content, fontSize = 12.sp, color = Black) },
         confirmButton = {

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/TimePickerDialog.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/TimePickerDialog.kt
@@ -35,6 +35,7 @@ fun TimePickerDialog(
     title: String,
     onConfirm: (TimePickerState) -> Unit,
     onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val currentTime = Calendar.getInstance()
     val timePickerState = rememberTimePickerState(
@@ -45,6 +46,7 @@ fun TimePickerDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
+        modifier = modifier,
         confirmButton = {
             TextButton(onClick = { onConfirm(timePickerState) }) {
                 Text(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/fab/PharmPrescriptionFAB.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/fab/PharmPrescriptionFAB.kt
@@ -13,10 +13,12 @@ import com.moon.pharm.component_ui.theme.Primary
 
 @Composable
 fun PharmPrescriptionFAB(
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     FloatingActionButton(
         onClick = onClick,
+        modifier = modifier,
         shape = RoundedCornerShape(100.dp),
         containerColor = Primary
     ) {

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
@@ -2,6 +2,7 @@ package com.moon.pharm.component_ui.component.input
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,6 +13,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
@@ -39,10 +41,13 @@ fun PrimaryTextField(
     shape: Shape = RoundedCornerShape(10.dp),
     contentAlignment: Alignment = Alignment.CenterStart
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     if (value != null) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
+            interactionSource = interactionSource,
             textStyle = textStyle,
             maxLines = maxLines,
             keyboardOptions = keyboardOptions,

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/SearchBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/SearchBar.kt
@@ -2,7 +2,14 @@ package com.moon.pharm.component_ui.component.input
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
@@ -10,6 +17,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +37,8 @@ fun SearchBar(
     placeholder: String,
     modifier: Modifier = Modifier
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -58,6 +68,7 @@ fun SearchBar(
                 BasicTextField(
                     value = value,
                     onValueChange = onValueChange,
+                    interactionSource = interactionSource,
                     textStyle = TextStyle(color = Color.Black, fontSize = 14.sp),
                     singleLine = true,
                     cursorBrush = SolidColor(primaryLight),

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
@@ -2,7 +2,17 @@ package com.moon.pharm.component_ui.component.item
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -20,23 +30,24 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.R
 import com.moon.pharm.component_ui.theme.Primary
 import com.moon.pharm.component_ui.theme.SecondFont
 import com.moon.pharm.component_ui.theme.White
 import com.moon.pharm.component_ui.theme.tertiaryLight
 import com.moon.pharm.domain.model.auth.Pharmacist
-import com.moon.pharm.component_ui.R
 
 @Composable
 fun PharmacistListItem(
     pharmacist: Pharmacist,
-    btnText: String? = null,
-    onSelect: (Pharmacist) -> Unit
+    onSelect: (Pharmacist) -> Unit,
+    modifier: Modifier = Modifier,
+    btnText: String? = null
 ) {
     val textToDisplay = btnText ?: stringResource(R.string.btn_select)
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .background(White, RoundedCornerShape(10.dp))
             .padding(16.dp),

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
@@ -2,7 +2,14 @@ package com.moon.pharm.component_ui.component.item
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
@@ -23,10 +30,11 @@ import com.moon.pharm.domain.model.pharmacy.Pharmacy
 @Composable
 fun PharmacyListItem(
     pharmacy: Pharmacy,
-    onClick: (Pharmacy) -> Unit
+    onClick: (Pharmacy) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clickable { onClick(pharmacy) }
             .background(White, RoundedCornerShape(10.dp))

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapSearchBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapSearchBar.kt
@@ -2,6 +2,7 @@ package com.moon.pharm.component_ui.component.map
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -17,6 +18,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -36,6 +38,7 @@ fun MapSearchBar(
     modifier: Modifier = Modifier
 ) {
     val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
 
     Column(
         modifier = modifier
@@ -45,6 +48,7 @@ fun MapSearchBar(
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
+            interactionSource = interactionSource,
             modifier = Modifier
                 .fillMaxWidth()
                 .background(White, RoundedCornerShape(10.dp)),

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyListPanel.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyListPanel.kt
@@ -1,6 +1,13 @@
 package com.moon.pharm.component_ui.component.map
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
@@ -12,19 +19,20 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.moon.pharm.component_ui.R
 import com.moon.pharm.component_ui.component.item.PharmacyListItem
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
-import com.moon.pharm.component_ui.R
 
 @Composable
 fun PharmacyListPanel(
     pharmacies: List<Pharmacy>,
-    onPharmacyClick: (Pharmacy) -> Unit
+    onPharmacyClick: (Pharmacy) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val focusManager = LocalFocusManager.current
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .heightIn(max = 400.dp)
             .padding(horizontal = 16.dp)

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyMap.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyMap.kt
@@ -34,13 +34,13 @@ import com.moon.pharm.domain.model.pharmacy.Pharmacy
 @Composable
 fun PharmacyMap(
     pharmacies: List<Pharmacy>,
-    selectedPharmacy: Pharmacy? = null,
     onPharmacyClick: (Pharmacy) -> Unit,
     onBackClick: () -> Unit,
-    showBackButton: Boolean = true,
     cameraPositionState: CameraPositionState,
-    isLocationEnabled: Boolean = false,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    selectedPharmacy: Pharmacy? = null,
+    showBackButton: Boolean = true,
+    isLocationEnabled: Boolean = false
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         GoogleMap(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacySelector.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacySelector.kt
@@ -41,6 +41,7 @@ fun PharmacySelector(
     onSearch: (String) -> Unit,
     onSearchArea: (Double, Double) -> Unit,
     onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
     isLocationEnabled: Boolean = false,
     sheetContent: (@Composable () -> Unit)? = null,
     bottomContent: @Composable () -> Unit = {},
@@ -50,8 +51,7 @@ fun PharmacySelector(
             LatLng(DEFAULT_LAT_SEOUL, DEFAULT_LNG_SEOUL),
             15f
         )
-    },
-    modifier: Modifier = Modifier
+    }
 ) {
     var searchText by remember { mutableStateOf("") }
     val scaffoldState = rememberBottomSheetScaffoldState()

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/snackbar/CustomSnackbar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/snackbar/CustomSnackbar.kt
@@ -50,6 +50,7 @@ private data class SnackbarStyle(
 @Composable
 fun CustomSnackbar(
     snackbarData: SnackbarData,
+    modifier: Modifier = Modifier,
     type: SnackbarType = SnackbarType.ERROR
 ) {
     val style = remember(type) {
@@ -76,7 +77,7 @@ fun CustomSnackbar(
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .padding(16.dp)
             .shadow(4.dp, RoundedCornerShape(12.dp))
             .clip(RoundedCornerShape(12.dp))

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistSearchView.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistSearchView.kt
@@ -58,8 +58,8 @@ fun PharmacistSearchView(
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            FilterChip(text = stringResource(R.string.consult_search_nearby), isSelected = true)
-            FilterChip(text = stringResource(R.string.consult_search_favorite), isSelected = false)
+            FilterChip(text = stringResource(R.string.consult_search_nearby), isSelected = true, onClick = {})
+            FilterChip(text = stringResource(R.string.consult_search_favorite), isSelected = false, onClick = {})
         }
 
         Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
- 입력 컴포넌트(PrimaryTextField, MapSearchBar 등)에 `remember { MutableInteractionSource() }`를 적용하여 상태 변화 시 불필요한 객체 재생성 및 리컴포지션 차단
- Compose API 가이드라인을 준수하여 모든 공통 컴포넌트의 `modifier` 파라미터를 필수 파라미터 직후로 재배치하고 기본값(Modifier = Modifier) 할당
- TimePickerDialog의 `Calendar.getInstance()`, PharmTopBar의 람다(`titleContent`) 등 렌더링 부하를 주는 객체에 `remember` 캐싱 적용
- CustomSnackbar, PharmacyListPanel 등에 외부 확장을 위한 `modifier` 파라미터 추가 및 최상위 레이아웃 연결
- FilterChip 파라미터 시그니처 변경(onClick 필수화)에 따라 PharmacistSearchView에서 발생한 사이드 이펙트 해결

Close #83