### PR TITLE
refactor(component-ui): PharmTheme 시스템 확장성 및 타입 안정성 강화

### DIFF
--- a/app/src/main/java/com/moon/pharm/ui/theme/Theme.kt
+++ b/app/src/main/java/com/moon/pharm/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.moon.pharm.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -21,16 +20,6 @@ private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
     tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
 )
 
 @Composable

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/SectionHeader.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/SectionHeader.kt
@@ -13,8 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.OnSurface
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun SectionHeader(
@@ -33,12 +32,12 @@ fun SectionHeader(
             text = title,
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            color = OnSurface
+            color = PharmTheme.colors.onSurface
         )
         TextButton(
             onClick = onMoreClick,
             colors = ButtonDefaults.textButtonColors(
-                contentColor = SecondFont
+                contentColor = PharmTheme.colors.secondFont
             )
         ) {
             Text(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/StatusBadge.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/StatusBadge.kt
@@ -15,15 +15,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.onPrimaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun StatusBadge(
     text: String,
     statusColor: Color,
     modifier: Modifier = Modifier,
-    contentColor: Color = onPrimaryLight,
+    contentColor: Color = PharmTheme.colors.onPrimary,
     useBorderedStyle: Boolean = false,
     leadingIcon: @Composable (() -> Unit)? = null
 ) {
@@ -49,8 +48,8 @@ fun StatusBadge(
 
         val textColor = when {
             useBorderedStyle -> statusColor
-            contentColor != onPrimaryLight -> contentColor
-            else -> White
+            contentColor != PharmTheme.colors.onPrimary -> contentColor
+            else -> PharmTheme.colors.surface
         }
 
         Text(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmBottomBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmBottomBar.kt
@@ -11,8 +11,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.model.BottomBarUiModel
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun PharmBottomBar(
@@ -21,7 +20,7 @@ fun PharmBottomBar(
     modifier: Modifier = Modifier
 ) {
     NavigationBar (
-        containerColor = backgroundLight,
+        containerColor = PharmTheme.colors.background,
         modifier = modifier.shadow(elevation = 10.dp)
     ){
         items.forEach { item ->
@@ -39,10 +38,10 @@ fun PharmBottomBar(
                     Text(text = item.tabName)
                 },
                 colors = NavigationBarItemDefaults.colors(
-                    selectedIconColor = Primary,
-                    selectedTextColor = Primary,
-                    unselectedIconColor = Color.Gray,
-                    unselectedTextColor = Color.Gray,
+                    selectedIconColor = PharmTheme.colors.primary,
+                    selectedTextColor = PharmTheme.colors.primary,
+                    unselectedIconColor = PharmTheme.colors.placeholder,
+                    unselectedTextColor = PharmTheme.colors.placeholder,
                     indicatorColor = Color.Transparent
                 )
             )

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTabs.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTabs.kt
@@ -9,9 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.backgroundLight
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun PharmPrimaryTabRow(
@@ -26,11 +24,11 @@ fun PharmPrimaryTabRow(
         indicator = {
             TabRowDefaults.SecondaryIndicator(
                 modifier = Modifier.tabIndicatorOffset(selectedTabIndex),
-                color = primaryLight
+                color = PharmTheme.colors.primary
             )
         },
-        containerColor = backgroundLight,
-        contentColor = primaryLight,
+        containerColor = PharmTheme.colors.background,
+        contentColor = PharmTheme.colors.primary,
         divider = {}
     ) {
         tabs.forEachIndexed { index, title ->
@@ -44,7 +42,7 @@ fun PharmPrimaryTabRow(
                         fontWeight = if (selectedTabIndex == index) FontWeight.Bold else FontWeight.Normal,
                     )
                 },
-                unselectedContentColor = SecondFont
+                unselectedContentColor = PharmTheme.colors.secondFont
             )
         }
     }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTopBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/bar/PharmTopBar.kt
@@ -28,9 +28,7 @@ import com.moon.pharm.component_ui.R
 import com.moon.pharm.component_ui.model.TopBarAction
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
-import com.moon.pharm.component_ui.theme.OnSurface
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 /**
  * 앱 표준 상단바
@@ -61,7 +59,7 @@ fun PharmTopBar(
             PharmActions(actions = data.actions)
         },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = backgroundLight
+            containerColor = PharmTheme.colors.background
         ),
         windowInsets = WindowInsets.statusBars,
         modifier = modifier
@@ -85,7 +83,7 @@ private fun PharmTextTitle(title: String) {
         text = title,
         fontSize = 20.sp,
         fontWeight = FontWeight.Bold,
-        color = Primary
+        color = PharmTheme.colors.primary
     )
 }
 
@@ -105,7 +103,7 @@ private fun PharmNavigationIcon(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = Primary
+            tint = PharmTheme.colors.primary
         )
     }
 }
@@ -118,14 +116,14 @@ private fun PharmActions(actions: List<TopBarAction>) {
                 Icon(
                     imageVector = action.icon,
                     contentDescription = action.text,
-                    tint = Primary
+                    tint = PharmTheme.colors.primary
                 )
             }
         } else if (action.text != null) {
             TextButton(onClick = action.onClick) {
                 Text(
                     text = action.text,
-                    color = OnSurface
+                    color = PharmTheme.colors.onSurface
                 )
             }
         }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/PharmButtons.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/PharmButtons.kt
@@ -17,9 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
-import com.moon.pharm.component_ui.theme.secondaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.MultipleEventsCutter
 
 /**
@@ -32,8 +30,8 @@ fun PharmPrimaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    containerColor: Color = primaryLight,
-    contentColor: Color = White
+    containerColor: Color = PharmTheme.colors.primary,
+    contentColor: Color = PharmTheme.colors.surface
 ) {
     val multipleEventsCutter = remember { MultipleEventsCutter.get() }
 
@@ -66,8 +64,8 @@ fun PharmSmallButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    containerColor: Color = secondaryLight,
-    contentColor: Color = White
+    containerColor: Color = PharmTheme.colors.secondary,
+    contentColor: Color = PharmTheme.colors.surface
 ) {
     val multipleEventsCutter = remember { MultipleEventsCutter.get() }
 
@@ -103,8 +101,8 @@ fun PharmOutlinedButton(
             .fillMaxWidth()
             .height(52.dp),
         shape = RoundedCornerShape(10.dp),
-        border = BorderStroke(1.dp, primaryLight),
-        colors = ButtonDefaults.outlinedButtonColors(contentColor = primaryLight)
+        border = BorderStroke(1.dp, PharmTheme.colors.primary),
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = PharmTheme.colors.primary)
     ) {
         content()
     }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/SelectButton.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/SelectButton.kt
@@ -13,10 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun SelectButton(
@@ -28,10 +25,10 @@ fun SelectButton(
     Box(
         modifier = modifier
             .height(40.dp)
-            .background(White, RoundedCornerShape(8.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(8.dp))
             .border(
                 width = if (isSelected) 1.dp else 0.5.dp,
-                color = if (isSelected) Primary else tertiaryLight,
+                color = if (isSelected) PharmTheme.colors.primary else PharmTheme.colors.tertiary,
                 shape = RoundedCornerShape(8.dp)
             )
             .clickable { onClick() },
@@ -41,7 +38,7 @@ fun SelectButton(
             text = text,
             fontSize = 14.sp,
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-            color = if (isSelected) Primary else SecondFont
+            color = if (isSelected) PharmTheme.colors.primary else PharmTheme.colors.secondFont
         )
     }
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/DateSettingCard.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/DateSettingCard.kt
@@ -17,11 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 
 @Composable
@@ -36,8 +32,8 @@ fun DateSettingCard(
         modifier = modifier
             .fillMaxWidth()
             .height(50.dp)
-            .background(White, RoundedCornerShape(10.dp))
-            .border(0.5.dp, tertiaryLight, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
+            .border(0.5.dp, PharmTheme.colors.tertiary, RoundedCornerShape(10.dp))
             .clickableSingle { onClick() }
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.CenterStart
@@ -45,14 +41,14 @@ fun DateSettingCard(
         Text(
             text = value.ifEmpty { placeholder },
             fontSize = 15.sp,
-            color = if (value.isEmpty()) Placeholder else Black
+            color = if (value.isEmpty()) PharmTheme.colors.placeholder else PharmTheme.colors.onSurface
         )
 
         if (showCalendarIcon) {
             Icon(
                 imageVector = Icons.Default.CalendarMonth,
                 contentDescription = null,
-                tint = Primary,
+                tint = PharmTheme.colors.primary,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
                     .size(24.dp)

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/HealthInfoCard.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/HealthInfoCard.kt
@@ -15,15 +15,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun HealthInfoCard(
@@ -39,7 +37,7 @@ fun HealthInfoCard(
             .width(110.dp)
             .clip(RoundedCornerShape(10.dp))
             .background(
-                color = White
+                color = PharmTheme.colors.surface
             )
             .clickable { onClick() },
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -61,7 +59,7 @@ fun HealthInfoCard(
                 text = title,
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Medium,
-                color = Color.Black,
+                color = PharmTheme.colors.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(bottom = 4.dp)
@@ -70,7 +68,7 @@ fun HealthInfoCard(
                 text = description,
                 fontSize = 9.sp,
                 fontWeight = FontWeight.Normal,
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/TimeSettingCard.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/card/TimeSettingCard.kt
@@ -20,11 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 
 @Composable
@@ -36,8 +32,8 @@ fun TimeSettingCard(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(10.dp))
-            .border(0.5.dp, tertiaryLight, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
+            .border(0.5.dp, PharmTheme.colors.tertiary, RoundedCornerShape(10.dp))
             .clickableSingle { onTimeClick() }
             .padding(10.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -48,7 +44,7 @@ fun TimeSettingCard(
                 text = time,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
-                color = if (time.isEmpty()) Placeholder else Black
+                color = if (time.isEmpty()) PharmTheme.colors.placeholder else PharmTheme.colors.onSurface
             )
         }
 
@@ -57,7 +53,7 @@ fun TimeSettingCard(
         Icon(
             imageVector = Icons.Default.Alarm,
             contentDescription = null,
-            tint = Primary,
+            tint = PharmTheme.colors.primary,
             modifier = Modifier
                 .size(24.dp)
         )

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/chip/FilterChip.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/chip/FilterChip.kt
@@ -14,10 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 
 @Composable
@@ -30,10 +27,10 @@ fun FilterChip(
     Box(
         modifier = modifier
             .height(32.dp)
-            .background(if (isSelected) Primary else White, RoundedCornerShape(10.dp))
+            .background(if (isSelected) PharmTheme.colors.primary else PharmTheme.colors.surface, RoundedCornerShape(10.dp))
             .border(
                 width = if (isSelected) 0.dp else 0.5.dp,
-                color = if (isSelected) Color.Transparent else tertiaryLight,
+                color = if (isSelected) Color.Transparent else PharmTheme.colors.tertiary,
                 shape = RoundedCornerShape(10.dp)
             )
             .clickableSingle { onClick() }
@@ -44,7 +41,7 @@ fun FilterChip(
             text = text,
             fontSize = 13.sp,
             fontWeight = FontWeight.Medium,
-            color = if (isSelected) White else SecondFont
+            color = if (isSelected) PharmTheme.colors.surface else PharmTheme.colors.secondFont
         )
     }
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/DatePickerModal.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/DatePickerModal.kt
@@ -9,14 +9,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryContainerLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun DatePickerModal(
@@ -35,29 +32,29 @@ fun DatePickerModal(
             }) {
                 Text(
                     stringResource(R.string.common_confirm),
-                    color = Primary, fontWeight = FontWeight.Bold)
+                    color = PharmTheme.colors.primary, fontWeight = FontWeight.Bold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(
                     stringResource(R.string.common_cancel),
-                    color = Primary)
+                    color = PharmTheme.colors.primary)
             }
         },
         shape = RoundedCornerShape(10.dp),
-        colors = DatePickerDefaults.colors(containerColor = tertiaryContainerLight)
+        colors = DatePickerDefaults.colors(containerColor = PharmTheme.colors.tertiaryContainer)
     ) {
         DatePicker(
             state = state,
             colors = DatePickerDefaults.colors(
-                containerColor = White,
-                titleContentColor = Color.Black,
-                headlineContentColor = Color.Black,
-                selectedDayContainerColor = Primary,
-                selectedDayContentColor = White,
-                todayContentColor = Primary,
-                todayDateBorderColor = Primary
+                containerColor = PharmTheme.colors.surface,
+                titleContentColor = PharmTheme.colors.onSurface,
+                headlineContentColor = PharmTheme.colors.onSurface,
+                selectedDayContainerColor = PharmTheme.colors.primary,
+                selectedDayContentColor = PharmTheme.colors.surface,
+                todayContentColor = PharmTheme.colors.primary,
+                todayDateBorderColor = PharmTheme.colors.primary
             )
         )
     }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmInfoDialog.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmInfoDialog.kt
@@ -7,8 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun PharmInfoDialog(
@@ -21,13 +20,13 @@ fun PharmInfoDialog(
         onDismissRequest = onDismiss,
         modifier = modifier,
         title = { Text(text = title, fontWeight = FontWeight.Bold, fontSize = 16.sp) },
-        text = { Text(text = content, fontSize = 12.sp, color = Black) },
+        text = { Text(text = content, fontSize = 12.sp, color = PharmTheme.colors.onSurface) },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text("닫기", color = Black)
+                Text("닫기", color = PharmTheme.colors.onSurface)
             }
         },
-        containerColor = White,
-        textContentColor = Black
+        containerColor = PharmTheme.colors.surface,
+        textContentColor = PharmTheme.colors.onSurface
     )
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/TimePickerDialog.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/TimePickerDialog.kt
@@ -20,14 +20,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.Tertiary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.onPrimaryContainerLight
-import com.moon.pharm.component_ui.theme.primaryContainerLight
-import com.moon.pharm.component_ui.theme.tertiaryLight
-import java.util.Calendar
 import com.moon.pharm.component_ui.R
+import com.moon.pharm.component_ui.theme.PharmTheme
+import java.util.Calendar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,7 +46,7 @@ fun TimePickerDialog(
             TextButton(onClick = { onConfirm(timePickerState) }) {
                 Text(
                     stringResource(R.string.common_confirm),
-                    color = Primary, fontWeight = FontWeight.Bold
+                    color = PharmTheme.colors.primary, fontWeight = FontWeight.Bold
                 )
             }
         },
@@ -59,7 +54,7 @@ fun TimePickerDialog(
             TextButton(onClick = onDismiss) {
                 Text(
                     stringResource(R.string.common_cancel),
-                    color = Primary
+                    color = PharmTheme.colors.primary
                 )
             }
         },
@@ -76,30 +71,30 @@ fun TimePickerDialog(
                 )
                 MaterialTheme(
                     colorScheme = MaterialTheme.colorScheme.copy(
-                        primary = Primary
+                        primary = PharmTheme.colors.primary
                     )
                 ) {
                     TimeInput(
                         state = timePickerState,
                         colors = TimePickerDefaults.colors(
-                            containerColor = White,
-                            timeSelectorSelectedContainerColor = primaryContainerLight,
-                            timeSelectorSelectedContentColor = onPrimaryContainerLight,
+                            containerColor = PharmTheme.colors.surface,
+                            timeSelectorSelectedContainerColor = PharmTheme.colors.primaryContainer,
+                            timeSelectorSelectedContentColor = PharmTheme.colors.onPrimaryContainer,
 
-                            timeSelectorUnselectedContainerColor = White,
-                            timeSelectorUnselectedContentColor = Tertiary,
+                            timeSelectorUnselectedContainerColor = PharmTheme.colors.surface,
+                            timeSelectorUnselectedContentColor = PharmTheme.colors.tertiary,
 
-                            periodSelectorSelectedContainerColor = primaryContainerLight,
-                            periodSelectorSelectedContentColor = onPrimaryContainerLight,
-                            periodSelectorUnselectedContainerColor = White,
-                            periodSelectorUnselectedContentColor = Tertiary,
-                            periodSelectorBorderColor = tertiaryLight
+                            periodSelectorSelectedContainerColor = PharmTheme.colors.primaryContainer,
+                            periodSelectorSelectedContentColor = PharmTheme.colors.onPrimaryContainer,
+                            periodSelectorUnselectedContainerColor = PharmTheme.colors.surface,
+                            periodSelectorUnselectedContentColor = PharmTheme.colors.tertiary,
+                            periodSelectorBorderColor = PharmTheme.colors.tertiary
                         )
                     )
                 }
             }
         },
         shape = RoundedCornerShape(10.dp),
-        containerColor = White
+        containerColor = PharmTheme.colors.surface
     )
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/fab/PharmPrescriptionFAB.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/fab/PharmPrescriptionFAB.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Primary
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun PharmPrescriptionFAB(
@@ -20,7 +20,7 @@ fun PharmPrescriptionFAB(
         onClick = onClick,
         modifier = modifier,
         shape = RoundedCornerShape(100.dp),
-        containerColor = Primary
+        containerColor = PharmTheme.colors.primary
     ) {
         Image(
             painter = painterResource(id = R.drawable.prescription_image),

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/PrimaryTextField.kt
@@ -21,10 +21,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun PrimaryTextField(
@@ -52,12 +49,12 @@ fun PrimaryTextField(
             maxLines = maxLines,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
-            cursorBrush = SolidColor(primaryLight),
+            cursorBrush = SolidColor(PharmTheme.colors.primary),
             modifier = modifier
                 .fillMaxWidth()
                 .height(height)
-                .background(White, shape)
-                .border(0.5.dp, tertiaryLight, shape),
+                .background(PharmTheme.colors.surface, shape)
+                .border(0.5.dp, PharmTheme.colors.tertiary, shape),
             decorationBox = { innerTextField ->
                 Box(
                     modifier = Modifier.padding(horizontal = 16.dp),
@@ -66,7 +63,7 @@ fun PrimaryTextField(
                     if (value.isEmpty()) {
                         Text(
                             text = placeholder,
-                            style = textStyle.copy(color = Placeholder)
+                            style = textStyle.copy(color = PharmTheme.colors.placeholder)
                         )
                     }
                     innerTextField()

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/SearchBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/input/SearchBar.kt
@@ -20,15 +20,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun SearchBar(
@@ -43,8 +39,8 @@ fun SearchBar(
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp)
-            .background(White, RoundedCornerShape(10.dp))
-            .border(0.5.dp, tertiaryLight, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
+            .border(0.5.dp, PharmTheme.colors.tertiary, RoundedCornerShape(10.dp))
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.CenterStart
     ) {
@@ -54,7 +50,7 @@ fun SearchBar(
             Icon(
                 imageVector = Icons.Default.Search,
                 contentDescription = null,
-                tint = Placeholder,
+                tint = PharmTheme.colors.placeholder,
                 modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.size(8.dp))
@@ -62,16 +58,16 @@ fun SearchBar(
                 if (value.isEmpty()) {
                     Text(
                         text = placeholder,
-                        style = TextStyle(color = Placeholder, fontSize = 14.sp)
+                        style = TextStyle(color = PharmTheme.colors.placeholder, fontSize = 14.sp)
                     )
                 }
                 BasicTextField(
                     value = value,
                     onValueChange = onValueChange,
                     interactionSource = interactionSource,
-                    textStyle = TextStyle(color = Color.Black, fontSize = 14.sp),
+                    textStyle = TextStyle(color = PharmTheme.colors.onSurface, fontSize = 14.sp),
                     singleLine = true,
-                    cursorBrush = SolidColor(primaryLight),
+                    cursorBrush = SolidColor(PharmTheme.colors.primary),
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
@@ -25,16 +25,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.Pharmacist
 
 @Composable
@@ -49,7 +45,7 @@ fun PharmacistListItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
@@ -59,14 +55,14 @@ fun PharmacistListItem(
                 modifier = Modifier
                     .size(48.dp)
                     .clip(CircleShape)
-                    .background(tertiaryLight)
-                    .border(1.dp, tertiaryLight, CircleShape),
+                    .background(PharmTheme.colors.tertiary)
+                    .border(1.dp, PharmTheme.colors.tertiary, CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     imageVector = Icons.Default.Image,
                     contentDescription = null,
-                    tint = Color.Gray,
+                    tint = PharmTheme.colors.placeholder,
                     modifier = Modifier.size(24.dp)
                 )
             }
@@ -76,19 +72,19 @@ fun PharmacistListItem(
                     text = pharmacist.name,
                     fontSize = 15.sp,
                     fontWeight = FontWeight.Bold,
-                    color = Color.Black
+                    color = PharmTheme.colors.onSurface
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = pharmacist.bio,
                     fontSize = 13.sp,
-                    color = SecondFont
+                    color = PharmTheme.colors.secondFont
                 )
             }
         }
         Button(
             onClick = { onSelect(pharmacist) },
-            colors = ButtonDefaults.buttonColors(containerColor = Primary),
+            colors = ButtonDefaults.buttonColors(containerColor = PharmTheme.colors.primary),
             shape = RoundedCornerShape(8.dp),
             modifier = Modifier
                 .height(36.dp)

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
@@ -18,13 +18,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 
 @Composable
@@ -37,14 +34,14 @@ fun PharmacyListItem(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onClick(pharmacy) }
-            .background(White, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = Icons.Default.LocationOn,
             contentDescription = null,
-            tint = Primary,
+            tint = PharmTheme.colors.primary,
             modifier = Modifier.size(24.dp)
         )
         Spacer(modifier = Modifier.width(12.dp))
@@ -53,12 +50,12 @@ fun PharmacyListItem(
                 text = pharmacy.name,
                 fontWeight = FontWeight.Bold,
                 fontSize = 15.sp,
-                color = Color.Black
+                color = PharmTheme.colors.onSurface
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = pharmacy.address,
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 fontSize = 13.sp
             )
         }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapRefreshButton.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapRefreshButton.kt
@@ -19,8 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun MapRefreshButton(
@@ -34,8 +33,8 @@ fun MapRefreshButton(
             .padding(top = 80.dp),
         shape = RoundedCornerShape(20.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = White,
-            contentColor = Primary
+            containerColor = PharmTheme.colors.surface,
+            contentColor = PharmTheme.colors.primary
         ),
         elevation = ButtonDefaults.buttonElevation(defaultElevation = 6.dp)
     ) {

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapSearchBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/MapSearchBar.kt
@@ -25,9 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun MapSearchBar(
@@ -51,7 +49,7 @@ fun MapSearchBar(
             interactionSource = interactionSource,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(White, RoundedCornerShape(10.dp)),
+                .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp)),
             placeholder = { Text(stringResource(R.string.search_pharmacy_placeholder)) },
             leadingIcon = {
                 Icon(
@@ -77,10 +75,10 @@ fun MapSearchBar(
             }),
             singleLine = true,
             colors = TextFieldDefaults.colors(
-                focusedContainerColor = White,
-                unfocusedContainerColor = White,
-                focusedIndicatorColor = Primary,
-                unfocusedIndicatorColor = Placeholder
+                focusedContainerColor = PharmTheme.colors.surface,
+                unfocusedContainerColor = PharmTheme.colors.surface,
+                focusedIndicatorColor = PharmTheme.colors.primary,
+                unfocusedIndicatorColor = PharmTheme.colors.placeholder
             ),
             shape = RoundedCornerShape(10.dp)
         )

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyListPanel.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyListPanel.kt
@@ -14,13 +14,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.R
 import com.moon.pharm.component_ui.component.item.PharmacyListItem
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 
 @Composable
@@ -50,7 +50,7 @@ fun PharmacyListPanel(
                     .height(100.dp),
                 contentAlignment = Alignment.Center
             ) {
-                Text(text = stringResource(R.string.search_result_empty), color = Color.Gray)
+                Text(text = stringResource(R.string.search_result_empty), color = PharmTheme.colors.placeholder)
             }
         } else {
             LazyColumn(

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyMap.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacyMap.kt
@@ -26,8 +26,7 @@ import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
 import com.moon.pharm.component_ui.R
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 
 @SuppressLint("UnrememberedMutableState")
@@ -75,7 +74,7 @@ fun PharmacyMap(
                     .padding(16.dp)
                     .statusBarsPadding()
                     .align(Alignment.TopStart),
-                colors = ButtonDefaults.buttonColors(containerColor = White),
+                colors = ButtonDefaults.buttonColors(containerColor = PharmTheme.colors.surface),
                 elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
                 contentPadding = PaddingValues(0.dp),
                 shape = CircleShape
@@ -83,7 +82,7 @@ fun PharmacyMap(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = stringResource(R.string.desc_back_button),
-                    tint = Black
+                    tint = PharmTheme.colors.onSurface
                 )
             }
         }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacySelector.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/map/PharmacySelector.kt
@@ -27,7 +27,7 @@ import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.moon.pharm.component_ui.common.DEFAULT_LAT_SEOUL
 import com.moon.pharm.component_ui.common.DEFAULT_LNG_SEOUL
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -87,7 +87,7 @@ fun PharmacySelector(
     BottomSheetScaffold(
         scaffoldState = scaffoldState,
         sheetPeekHeight = 80.dp,
-        sheetContainerColor = White,
+        sheetContainerColor = PharmTheme.colors.surface,
         sheetContent = {
             if (sheetContent != null) {
                 sheetContent()

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/progress/CircularProgressBar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/progress/CircularProgressBar.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun CircularProgressBar(
@@ -16,7 +16,7 @@ fun CircularProgressBar(
         contentAlignment = Alignment.Center
     ){
         CircularProgressIndicator(
-            color = tertiaryLight
+            color = PharmTheme.colors.tertiary
         )
     }
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/snackbar/CustomSnackbar.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/snackbar/CustomSnackbar.kt
@@ -26,15 +26,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.InfoContainer
-import com.moon.pharm.component_ui.theme.OnInfoContainer
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.Success
-import com.moon.pharm.component_ui.theme.SuccessContainer
-import com.moon.pharm.component_ui.theme.errorContainerLight
-import com.moon.pharm.component_ui.theme.errorLight
-import com.moon.pharm.component_ui.theme.onErrorContainerLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 enum class SnackbarType {
     SUCCESS, ERROR, INFO
@@ -53,25 +45,27 @@ fun CustomSnackbar(
     modifier: Modifier = Modifier,
     type: SnackbarType = SnackbarType.ERROR
 ) {
+    val colors = PharmTheme.colors
+
     val style = remember(type) {
         when (type) {
             SnackbarType.SUCCESS -> SnackbarStyle(
-                containerColor = SuccessContainer,
+                containerColor = colors.successContainer,
                 icon = Icons.Default.CheckCircle,
-                iconColor = Success,
-                textColor = Black.copy(alpha = 0.8f)
+                iconColor = colors.success,
+                textColor = colors.onSurface.copy(alpha = 0.8f)
             )
             SnackbarType.ERROR -> SnackbarStyle(
-                containerColor = errorContainerLight,
+                containerColor = colors.errorContainer,
                 icon = Icons.Default.Error,
-                iconColor = errorLight,
-                textColor = onErrorContainerLight
+                iconColor = colors.error,
+                textColor = colors.onErrorContainer
             )
             SnackbarType.INFO -> SnackbarStyle(
-                containerColor = InfoContainer,
+                containerColor = colors.infoContainer,
                 icon = Icons.Default.Info,
-                iconColor = Primary,
-                textColor = OnInfoContainer
+                iconColor = colors.primary,
+                textColor = colors.onInfoContainer
             )
         }
     }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/toggle/CustomSwitch.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/toggle/CustomSwitch.kt
@@ -6,9 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
-import com.moon.pharm.component_ui.theme.Placeholder
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun CustomSwitch(
@@ -20,10 +18,10 @@ fun CustomSwitch(
         checked = checked,
         onCheckedChange = onCheckedChange,
         colors = SwitchDefaults.colors(
-            checkedThumbColor = White,
-            checkedTrackColor = Primary,
-            uncheckedThumbColor = White,
-            uncheckedTrackColor = Placeholder,
+            checkedThumbColor = PharmTheme.colors.surface,
+            checkedTrackColor = PharmTheme.colors.primary,
+            uncheckedThumbColor = PharmTheme.colors.surface,
+            uncheckedTrackColor = PharmTheme.colors.placeholder,
             uncheckedBorderColor = Color.Transparent
         ),
         modifier = modifier.scale(0.7f)

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/theme/PharmColors.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/theme/PharmColors.kt
@@ -1,85 +1,105 @@
 package com.moon.pharm.component_ui.theme
 
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
-// 사용자가 정의한 핵심 색상
-val Primary = Color(0xFF1F3B58)
-val Secondary = Color(0xFF5E4B3B)
-val Tertiary = Color(0xFFB1CBDC)
-val White = Color(0xFFFFFFFF) // 기본 흰색 추가
-val Black = Color(0xFF000000) // 기본 검은색 추가
-val Background = Color(0xFFF2F4F7)
-val SecondFont = Color(0xFF767676)
-val OnSurface = Color(0xFF1F3B58)
-val Placeholder = Color(0xFFBDBDBD)
+// Primitive Colors
+private val BluePrimary = Color(0xFF1F3B58)
+private val BrownSecondary = Color(0xFF5E4B3B)
+private val BlueTertiary = Color(0xFFB1CBDC)
+private val WhiteColor = Color(0xFFFFFFFF)
+private val BlackColor = Color(0xFF000000)
+private val BackgroundColor = Color(0xFFF2F4F7)
+private val GraySecondFont = Color(0xFF767676)
+private val GrayPlaceholder = Color(0xFFBDBDBD)
+// --- 스낵바 및 상태 표시용 원시 색상 ---
+private val GreenSuccess = Color(0xFF2E7D32)
+private val GreenSuccessContainer = Color(0xFFE8F5E9)
+private val BlueInfoContainer = Color(0xFFE3F2FD)
+private val OrangeWarning = Color(0xFFF57C00)
+private val OrangeWarningContainer = Color(0xFFFFF3E0)
 
-// Material3 Color Scheme에 맞춘 매핑 (Light Theme 기준)
-/* Primary: 화면에서 가장 많이 쓰이는 주요 색상 (버튼, 활성 탭, 주요 아이콘 등) */
-val primaryLight = Primary
+// Semantic Colors
+data class PharmColorPalette(
+    val primary: Color,
+    val onPrimary: Color,
+    val primaryContainer: Color,
+    val onPrimaryContainer: Color,
 
-/* OnPrimary: Primary 색상 위에 올라가는 텍스트나 아이콘 색상 (보통 흰색) */
-val onPrimaryLight = White
+    val secondary: Color,
+    val onSecondary: Color,
+    val secondaryContainer: Color,
+    val onSecondaryContainer: Color,
 
-/* PrimaryContainer: Primary보다 연한 배경색 (강조 박스, 선택된 아이템 배경 등) */
-val primaryContainerLight = Tertiary // Primary와 어울리는 연한 톤으로 Tertiary 활용
+    val tertiary: Color,
+    val onTertiary: Color,
+    val tertiaryContainer: Color,
+    val onTertiaryContainer: Color,
 
-/* OnPrimaryContainer: PrimaryContainer 위에 올라가는 텍스트 색상 */
-val onPrimaryContainerLight = Color(0xFF001E30) // Primary보다 더 진한 텍스트
+    val error: Color,
+    val onError: Color,
+    val errorContainer: Color,
+    val onErrorContainer: Color,
 
-/* Secondary: Primary 다음으로 강조하고 싶은 요소 (FAB, 보조 버튼, 선택 컨트롤 등) */
-val secondaryLight = Secondary
+    val background: Color,
+    val onBackground: Color,
+    val surface: Color,
+    val onSurface: Color,
+    val placeholder: Color,
+    val secondFont: Color,
 
-/* OnSecondary: Secondary 색상 위에 올라가는 텍스트나 아이콘 색상 */
-val onSecondaryLight = White
+    // 커스텀 상태 색상
+    val success: Color,
+    val successContainer: Color,
+    val infoContainer: Color,
+    val onInfoContainer: Color,
+    val warning: Color,
+    val warningContainer: Color
+)
 
-/* SecondaryContainer: Secondary보다 연한 배경색 (보조 강조 박스 등) */
-val secondaryContainerLight = Color(0xFFE6DED5) // Secondary의 연한 파생색 (임의 생성)
+// 라이트 모드
+val LightColorPalette = PharmColorPalette(
+    primary = BluePrimary,
+    onPrimary = WhiteColor,
+    primaryContainer = BlueTertiary,
+    onPrimaryContainer = Color(0xFF001E30),
 
-/* OnSecondaryContainer: SecondaryContainer 위에 올라가는 텍스트 색상 */
-val onSecondaryContainerLight = Color(0xFF24190F) // Secondary보다 진한 텍스트
+    secondary = BrownSecondary,
+    onSecondary = WhiteColor,
+    secondaryContainer = Color(0xFFE6DED5),
+    onSecondaryContainer = Color(0xFF24190F),
 
-/* Tertiary: Primary, Secondary와 대조를 이루거나 포인트를 줄 때 사용 (차트, 강조 등) */
-val tertiaryLight = Tertiary
+    tertiary = BlueTertiary,
+    onTertiary = Color(0xFF00344D),
+    tertiaryContainer = Color(0xFFCDE6F6),
+    onTertiaryContainer = Color(0xFF001E30),
 
-/* OnTertiary: Tertiary 색상 위에 올라가는 텍스트나 아이콘 색상 */
-val onTertiaryLight = Color(0xFF00344D) // Tertiary 위에서의 텍스트
+    error = Color(0xFFBA1A1A),
+    onError = WhiteColor,
+    errorContainer = Color(0xFFFFDAD6),
+    onErrorContainer = Color(0xFF410002),
 
-/* TertiaryContainer: Tertiary보다 연한 배경색 */
-val tertiaryContainerLight = Color(0xFFCDE6F6) // 더 연한 Tertiary
+    background = BackgroundColor,
+    onBackground = BlackColor,
+    surface = WhiteColor,
+    onSurface = BlackColor,
+    placeholder = GrayPlaceholder,
+    secondFont = GraySecondFont,
 
-/* OnTertiaryContainer: TertiaryContainer 위에 올라가는 텍스트 색상 */
-val onTertiaryContainerLight = Color(0xFF001E30)
+    success = GreenSuccess,
+    successContainer = GreenSuccessContainer,
+    infoContainer = BlueInfoContainer,
+    onInfoContainer = BluePrimary,
+    warning = OrangeWarning,
+    warningContainer = OrangeWarningContainer
+)
 
-/* Error: 오류 상태를 나타내는 색상 (경고 문구, 삭제 버튼 등) */
-val errorLight = Color(0xFFBA1A1A)
+// 다크 모드
+val DarkColorPalette = LightColorPalette.copy(
+    // TODO: 향후 다크 모드용 색상으로 덮어쓰기
+)
 
-/* OnError: Error 색상 위에 올라가는 텍스트 색상 */
-val onErrorLight = White
-
-/* ErrorContainer: Error보다 연한 배경색 (오류 메시지 박스 배경 등) */
-val errorContainerLight = Color(0xFFFFDAD6)
-
-/* OnErrorContainer: ErrorContainer 위에 올라가는 텍스트 색상 */
-val onErrorContainerLight = Color(0xFF410002)
-
-/* Background: 앱의 전체적인 배경색 (Scaffold의 기본 배경) */
-val backgroundLight = Background // 배경색
-
-/* OnBackground: Background 위에 올라가는 텍스트나 아이콘 색상 (일반 텍스트) */
-val onBackgroundLight = Black
-
-/* Surface: 카드, 시트, 메뉴 등 표면 요소의 배경색 */
-val surfaceLight = White
-
-/* OnSurface: Surface 위에 올라가는 텍스트나 아이콘 색상 */
-val onSurfaceLight = Black
-
-/* --- 스낵바 및 상태 표시용 추가 색상 --- */
-val Success = Color(0xFF2E7D32)       // 아이콘/텍스트용 진한 녹색
-val SuccessContainer = Color(0xFFE8F5E9) // 배경용 아주 연한 녹색
-
-val InfoContainer = Color(0xFFE3F2FD) // 배경용 아주 연한 하늘색
-val OnInfoContainer = Primary // 텍스트용
-
-val Warning = Color(0xFFF57C00)
-val WarningContainer = Color(0xFFFFF3E0)
+// CompositionLocal
+val LocalPharmColors = staticCompositionLocalOf<PharmColorPalette> {
+    error("PharmColors not provided. Did you wrap your content in PharmMasterTheme?")
+}

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/theme/PharmTheme.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/theme/PharmTheme.kt
@@ -1,51 +1,64 @@
 package com.moon.pharm.component_ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.CompositionLocalProvider
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Primary,
-    secondary = Secondary,
-    tertiary = Tertiary
-)
+fun PharmColorPalette.toMaterialColorScheme(): ColorScheme {
+    return lightColorScheme(
+        primary = this.primary,
+        onPrimary = this.onPrimary,
+        primaryContainer = this.primaryContainer,
+        onPrimaryContainer = this.onPrimaryContainer,
+        secondary = this.secondary,
+        onSecondary = this.onSecondary,
+        secondaryContainer = this.secondaryContainer,
+        onSecondaryContainer = this.onSecondaryContainer,
+        tertiary = this.tertiary,
+        onTertiary = this.onTertiary,
+        tertiaryContainer = this.tertiaryContainer,
+        onTertiaryContainer = this.onTertiaryContainer,
+        error = this.error,
+        onError = this.onError,
+        errorContainer = this.errorContainer,
+        onErrorContainer = this.onErrorContainer,
+        background = this.background,
+        onBackground = this.onBackground,
+        surface = this.surface,
+        onSurface = this.onSurface
+    )
+}
 
-private val LightColorScheme = lightColorScheme(
-    primary = Primary,
-    secondary = Secondary,
-    tertiary = Tertiary,
+object PharmTheme {
+    val colors: PharmColorPalette
+        @Composable
+        get() = LocalPharmColors.current
 
-    background = backgroundLight,
-    surface = White,
-    onBackground = Primary,
-    onSurface = SecondFont,
-)
+    // 향후 Typography 작업 시 주석 해제하여 사용
+    // val typography: PharmTypography
+    //     @Composable
+    //     get() = LocalPharmTypography.current
+}
 
 @Composable
 fun PharmMasterTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    val colors = if (darkTheme) DarkColorPalette else LightColorPalette
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    CompositionLocalProvider(
+        LocalPharmColors provides colors,
+        LocalContentColor provides colors.onBackground
+    ) {
+        MaterialTheme(
+            colorScheme = colors.toMaterialColorScheme(),
+//            typography = Typography,
+            content = content
+        )
     }
-
-    MaterialTheme(
-        colorScheme = colorScheme,
-//        typography = Typography,
-        content = content
-    )
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultResourceMapper.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultResourceMapper.kt
@@ -1,18 +1,18 @@
 package com.moon.pharm.consult.mapper
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.moon.pharm.component_ui.theme.onPrimaryLight
-import com.moon.pharm.component_ui.theme.onSecondaryLight
-import com.moon.pharm.component_ui.theme.primaryLight
-import com.moon.pharm.component_ui.theme.secondaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.consult.ConsultStatus
 
+@Composable
 fun ConsultStatus.toBackgroundColor(): Color = when(this) {
-    ConsultStatus.WAITING -> secondaryLight
-    ConsultStatus.COMPLETED -> primaryLight
+    ConsultStatus.WAITING -> PharmTheme.colors.secondary
+    ConsultStatus.COMPLETED -> PharmTheme.colors.primary
 }
 
+@Composable
 fun ConsultStatus.toTextColor(): Color = when(this) {
-    ConsultStatus.WAITING -> onSecondaryLight
-    ConsultStatus.COMPLETED -> onPrimaryLight
+    ConsultStatus.WAITING -> PharmTheme.colors.onSecondary
+    ConsultStatus.COMPLETED -> PharmTheme.colors.onPrimary
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/AnswerContentCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/AnswerContentCard.kt
@@ -10,12 +10,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
 import com.moon.pharm.consult.R
 import com.moon.pharm.domain.model.consult.ConsultAnswer
@@ -26,14 +24,14 @@ fun AnswerContentCard(
 ) {
     Surface(
         shape = RoundedCornerShape(10.dp),
-        color = White,
+        color = PharmTheme.colors.surface,
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(modifier = Modifier.padding(20.dp)) {
             Text(
                 text = answer.content,
                 fontSize = 14.sp,
-                color = Color.Black,
+                color = PharmTheme.colors.onSurface,
                 lineHeight = 22.sp
             )
 
@@ -45,7 +43,7 @@ fun AnswerContentCard(
                     answer.createdAt.toDisplayDateTimeString()
                 ),
                 fontSize = 12.sp,
-                color = SecondFont
+                color = PharmTheme.colors.secondFont
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultConfirmContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultConfirmContent.kt
@@ -17,9 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
-import com.moon.pharm.component_ui.theme.backgroundLight
-import com.moon.pharm.component_ui.theme.primaryLight
-import com.moon.pharm.component_ui.theme.secondaryContainerLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -34,21 +32,21 @@ fun ConsultConfirmContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
             .padding(horizontal = 24.dp, vertical = 20.dp)
     ) {
         Text(
             text = stringResource(R.string.consult_confirm_title),
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            color = primaryLight,
+            color = PharmTheme.colors.primary,
             modifier = Modifier.padding(bottom = 20.dp)
         )
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(secondaryContainerLight, RoundedCornerShape(10.dp))
+                .background(PharmTheme.colors.secondaryContainer, RoundedCornerShape(10.dp))
                 .padding(10.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultContent.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.moon.pharm.component_ui.component.bar.PharmPrimaryTabRow
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.model.ConsultPrimaryTab
 import com.moon.pharm.domain.model.consult.ConsultItem
 
@@ -24,7 +24,7 @@ fun ConsultContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
     ) {
         PharmPrimaryTabRow(
             selectedTabIndex = selectedTab.index,

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
@@ -15,8 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.progress.CircularProgressBar
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.screen.section.AnswerSection
 import com.moon.pharm.consult.screen.section.PharmacistAnswerInputSection
@@ -40,13 +39,13 @@ fun ConsultDetailContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
     ) {
         if (item != null) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(backgroundLight)
+                    .background(PharmTheme.colors.background)
                     .padding(horizontal = 24.dp, vertical = 20.dp)
             ) {
                 item {
@@ -82,7 +81,7 @@ fun ConsultDetailContent(
             ) {
                 Text(
                     text = stringResource(R.string.consult_detail_error_load),
-                    color = SecondFont,
+                    color = PharmTheme.colors.secondFont,
                     fontSize = 16.sp
                 )
             }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultImageItem.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultImageItem.kt
@@ -9,12 +9,12 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -25,8 +25,8 @@ fun ConsultImageItem(imageUrl: String) {
         modifier = Modifier
             .size(100.dp)
             .clip(RoundedCornerShape(8.dp))
-            .background(Color.LightGray.copy(alpha = 0.2f))
-            .border(1.dp, Color.LightGray.copy(alpha = 0.5f), RoundedCornerShape(8.dp)),
+            .background(PharmTheme.colors.placeholder.copy(alpha = 0.2f))
+            .border(1.dp, PharmTheme.colors.placeholder.copy(alpha = 0.5f), RoundedCornerShape(8.dp)),
         contentScale = ContentScale.Crop,
         error = rememberVectorPainter(Icons.Default.Image),
         placeholder = rememberVectorPainter(Icons.Default.Image)

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
@@ -24,9 +24,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.StatusBadge
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
 import com.moon.pharm.consult.R
@@ -47,7 +45,7 @@ fun ConsultItemCard(
     val hasPermission = !isSecret || isOwner || isAssignedPharmacist
 
     ElevatedCard(
-        colors = CardDefaults.elevatedCardColors(containerColor = White),
+        colors = CardDefaults.elevatedCardColors(containerColor = PharmTheme.colors.surface),
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
         modifier = Modifier
             .fillMaxWidth()
@@ -66,7 +64,7 @@ fun ConsultItemCard(
                         Icon(
                             imageVector = Icons.Default.Lock,
                             contentDescription = stringResource(R.string.consult_secret_icon_desc),
-                            tint = if (hasPermission) primaryLight else SecondFont,
+                            tint = if (hasPermission) PharmTheme.colors.primary else PharmTheme.colors.secondFont,
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
@@ -76,7 +74,7 @@ fun ConsultItemCard(
                         text = if (hasPermission) item.title else stringResource(R.string.consult_secret_hidden_title),
                         fontSize = 15.sp,
                         fontWeight = FontWeight.SemiBold,
-                        color = if (hasPermission) primaryLight else SecondFont,
+                        color = if (hasPermission) PharmTheme.colors.primary else PharmTheme.colors.secondFont,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         lineHeight = 20.sp
@@ -87,7 +85,7 @@ fun ConsultItemCard(
                 Text(
                     text = "${item.nickName} • ${item.createdAt.toDisplayDateTimeString()}",
                     fontSize = 12.sp,
-                    color = SecondFont
+                    color = PharmTheme.colors.secondFont
                 )
             }
 

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultList.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultList.kt
@@ -18,8 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.domain.model.consult.ConsultItem
 
@@ -35,21 +34,21 @@ fun ConsultList(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .background(backgroundLight),
+                .background(PharmTheme.colors.background),
             contentAlignment = Alignment.Center
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
                     text = stringResource(R.string.consult_list_empty_title),
                     fontSize = 16.sp,
-                    color = SecondFont,
+                    color = PharmTheme.colors.secondFont,
                     fontWeight = FontWeight.Medium
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = stringResource(R.string.consult_list_empty_subtitle),
                     fontSize = 14.sp,
-                    color = SecondFont.copy(alpha = 0.7f)
+                    color = PharmTheme.colors.secondFont.copy(alpha = 0.7f)
                 )
             }
         }
@@ -59,7 +58,7 @@ fun ConsultList(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = modifier
                 .fillMaxSize()
-                .background(backgroundLight)
+                .background(PharmTheme.colors.background)
         ) {
             items(
                 items = currentList, key = { it.id }) { item ->

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultPrivacyToggle.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultPrivacyToggle.kt
@@ -14,8 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.toggle.CustomSwitch
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -35,7 +34,7 @@ fun ConsultPrivacyToggle(
         Column {
             Text(
                 text = stringResource(R.string.consult_write_public_setting_title),
-                color = Primary,
+                color = PharmTheme.colors.primary,
                 fontWeight = FontWeight.Bold,
                 fontSize = 16.sp
             )
@@ -43,7 +42,7 @@ fun ConsultPrivacyToggle(
                 text = if (isPublic) stringResource(R.string.consult_write_public_desc_all)
                 else stringResource(R.string.consult_write_public_desc_private),
                 fontSize = 12.sp,
-                color = SecondFont
+                color = PharmTheme.colors.secondFont
             )
         }
         CustomSwitch(

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteContent.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun ConsultWriteContent(
@@ -31,7 +31,7 @@ fun ConsultWriteContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
             .imePadding()
             .padding(horizontal = 24.dp)
             .padding(top = 20.dp, bottom = 10.dp)

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
@@ -18,8 +18,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.input.PrimaryTextField
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.screen.section.PhotoAttachmentSection
 
@@ -44,7 +43,7 @@ fun ConsultWriteForm(
             textStyle = TextStyle(
                 fontSize = 18.sp,
                 fontWeight = FontWeight.Normal,
-                color = Black
+                color = PharmTheme.colors.onSurface
             ),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -59,7 +58,7 @@ fun ConsultWriteForm(
             placeholder = stringResource(R.string.consult_write_placeholder_content),
             textStyle = TextStyle(
                 fontSize = 16.sp,
-                color = primaryLight,
+                color = PharmTheme.colors.primary,
                 lineHeight = 24.sp
             ),
             singleLine = false,

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/GuidanceBox.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/GuidanceBox.kt
@@ -14,27 +14,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun GuidanceBox(text: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .border(1.dp, primaryLight, RoundedCornerShape(10.dp))
+            .border(1.dp, PharmTheme.colors.primary, RoundedCornerShape(10.dp))
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = null,
-            tint = primaryLight,
+            tint = PharmTheme.colors.primary,
             modifier = Modifier.padding(end = 12.dp)
         )
         Text(
             text = text,
             fontSize = 13.sp,
-            color = primaryLight,
+            color = PharmTheme.colors.primary,
             lineHeight = 20.sp
         )
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/InfoCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/InfoCard.kt
@@ -17,9 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.button.PharmSmallButton
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -27,7 +25,7 @@ fun InfoCard(label: String, content: String, onEditClick: () -> Unit = {}) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
             .padding(12.dp)
     ) {
         Row(
@@ -39,14 +37,14 @@ fun InfoCard(label: String, content: String, onEditClick: () -> Unit = {}) {
                 Text(
                     text = label,
                     fontSize = 12.sp,
-                    color = SecondFont,
+                    color = PharmTheme.colors.secondFont,
                     modifier = Modifier.padding(bottom = 4.dp)
                 )
                 Text(
                     text = content,
                     fontSize = 15.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = primaryLight,
+                    color = PharmTheme.colors.primary,
                     maxLines = 2
                 )
             }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MapFindBanner.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MapFindBanner.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -39,8 +39,8 @@ fun MapFindBanner(
             .background(
                 brush = Brush.linearGradient(
                     colors = listOf(
-                        Color(0xFFE3F2FD),
-                        Color(0xFFF3E5F5)
+                        PharmTheme.colors.infoContainer,
+                        PharmTheme.colors.primaryContainer
                     )
                 )
             )
@@ -54,7 +54,7 @@ fun MapFindBanner(
             Icon(
                 imageVector = Icons.Default.Map,
                 contentDescription = stringResource(R.string.desc_map_icon),
-                tint = Primary,
+                tint = PharmTheme.colors.primary,
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.height(8.dp))
@@ -62,7 +62,7 @@ fun MapFindBanner(
                 text = stringResource(R.string.consult_map_search_placeholder),
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Bold,
-                color = Primary
+                color = PharmTheme.colors.primary
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultEmptyView.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/MyConsultEmptyView.kt
@@ -3,7 +3,7 @@ package com.moon.pharm.consult.screen.component
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun MyConsultEmptyView(
@@ -13,6 +13,6 @@ fun MyConsultEmptyView(
     Text(
         text = text,
         modifier = modifier,
-        color = SecondFont
+        color = PharmTheme.colors.secondFont
     )
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistListPanel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistListPanel.kt
@@ -20,9 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.item.PharmacistListItem
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.domain.model.auth.Pharmacist
 
@@ -36,7 +34,7 @@ fun PharmacistListPanel(
         modifier = Modifier
             .fillMaxWidth()
             .background(
-                color = White,
+                color = PharmTheme.colors.surface,
                 shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
             )
             .padding(24.dp)
@@ -46,7 +44,7 @@ fun PharmacistListPanel(
             text = stringResource(R.string.consult_map_pharmacist_list_format, pharmacyName),
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
-            color = Black,
+            color = PharmTheme.colors.onSurface,
             modifier = Modifier.padding(bottom = 12.dp)
         )
 
@@ -57,7 +55,7 @@ fun PharmacistListPanel(
                     .padding(20.dp),
                 contentAlignment = Alignment.Center
             ) {
-                Text(stringResource(R.string.consult_map_no_pharmacist), color = SecondFont)
+                Text(stringResource(R.string.consult_map_no_pharmacist), color = PharmTheme.colors.secondFont)
             }
         } else {
             LazyColumn(

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileCard.kt
@@ -15,8 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.domain.model.auth.Pharmacist
 
@@ -27,7 +26,7 @@ fun PharmacistProfileCard(
 ) {
     Surface(
         shape = RoundedCornerShape(10.dp),
-        color = White,
+        color = PharmTheme.colors.surface,
         modifier = Modifier.fillMaxWidth()
     ) {
         Row(
@@ -48,7 +47,7 @@ fun PharmacistProfileCard(
                 Text(
                     text = stringResource(R.string.consult_detail_no_pharmacist_info),
                     fontSize = 13.sp,
-                    color = SecondFont
+                    color = PharmTheme.colors.secondFont
                 )
             }
         }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileImage.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistProfileImage.kt
@@ -11,12 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -37,13 +37,13 @@ fun PharmacistProfileImage(imageUrl: String?) {
             modifier = Modifier
                 .size(40.dp)
                 .clip(CircleShape)
-                .background(Color.LightGray),
+                .background(PharmTheme.colors.placeholder),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = Icons.Default.Person,
                 contentDescription = null,
-                tint = Color.White
+                tint = PharmTheme.colors.surface
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistSearchView.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/PharmacistSearchView.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -21,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.chip.FilterChip
 import com.moon.pharm.component_ui.component.input.SearchBar
 import com.moon.pharm.component_ui.component.item.PharmacyListItem
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 import com.moon.pharm.domain.model.pharmacy.Pharmacy
 
@@ -36,14 +35,14 @@ fun PharmacistSearchView(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
             .padding(horizontal = 24.dp, vertical = 20.dp)
     ) {
         Text(
             text = stringResource(R.string.consult_search_select_pharmacist),
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
-            color = Color.Black,
+            color = PharmTheme.colors.onSurface,
             modifier = Modifier.padding(bottom = 16.dp)
         )
 

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/WaitingForAnswerBox.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/WaitingForAnswerBox.kt
@@ -18,10 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -29,15 +26,15 @@ fun WaitingForAnswerBox() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(10.dp))
-            .border(1.dp, primaryLight, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
+            .border(1.dp, PharmTheme.colors.primary, RoundedCornerShape(10.dp))
             .padding(15.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = Icons.Default.Info,
             contentDescription = null,
-            tint = Primary,
+            tint = PharmTheme.colors.primary,
             modifier = Modifier.padding(end = 10.dp)
         )
         Column {
@@ -45,12 +42,12 @@ fun WaitingForAnswerBox() {
                 text = stringResource(R.string.consult_status_waiting_title),
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Bold,
-                color = Primary
+                color = PharmTheme.colors.primary
             )
             Text(
                 text = stringResource(R.string.consult_status_waiting_subtitle),
                 fontSize = 13.sp,
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 modifier = Modifier.padding(top = 4.dp)
             )
         }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
 import com.moon.pharm.component_ui.component.input.PrimaryTextField
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -32,14 +30,14 @@ fun PharmacistAnswerInputSection(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
             .padding(16.dp)
     ) {
         Text(
             text = "약사님, 답변을 등록해주세요",
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
-            color = Primary
+            color = PharmTheme.colors.primary
         )
         Spacer(modifier = Modifier.height(12.dp))
 
@@ -49,7 +47,7 @@ fun PharmacistAnswerInputSection(
             placeholder = stringResource(R.string.consult_answer_write_placeholder_content),
             textStyle = TextStyle(
                 fontSize = 16.sp,
-                color = primaryLight,
+                color = PharmTheme.colors.primary,
                 lineHeight = 24.sp
             ),
             singleLine = false,

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PhotoAttachmentSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PhotoAttachmentSection.kt
@@ -31,8 +31,7 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.moon.pharm.component_ui.component.button.PharmOutlinedButton
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.consult.R
 
 @Composable
@@ -74,17 +73,17 @@ fun PhotoAttachmentSection(
                                 .align(Alignment.BottomStart)
                                 .size(80.dp)
                                 .clip(RoundedCornerShape(10.dp))
-                                .background(Color.LightGray)
+                                .background(PharmTheme.colors.placeholder)
                         )
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = stringResource(R.string.consult_photo_delete_desc),
-                            tint = White,
+                            tint = PharmTheme.colors.surface,
                             modifier = Modifier
                                 .align(Alignment.TopEnd)
                                 .size(20.dp)
                                 .clip(CircleShape)
-                                .background(Primary)
+                                .background(PharmTheme.colors.primary)
                                 .clickable { onRemoveImage(imageUrl) }
                                 .padding(4.dp)
                         )

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/QuestionSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/QuestionSection.kt
@@ -18,11 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.StatusBadge
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Secondary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
 import com.moon.pharm.consult.screen.component.ConsultImageItem
 import com.moon.pharm.domain.model.consult.ConsultItem
@@ -39,7 +35,7 @@ fun QuestionSection(item: ConsultItem) {
             Text(
                 text = "${item.nickName} • ${item.createdAt.toDisplayDateTimeString()}",
                 fontSize = 13.sp,
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 modifier = Modifier
                     .weight(1f)
                     .padding(end = 8.dp),
@@ -48,8 +44,8 @@ fun QuestionSection(item: ConsultItem) {
             )
             StatusBadge(
                 text = item.status.label,
-                statusColor = if (item.status == ConsultStatus.WAITING) Secondary else Primary,
-                contentColor = White
+                statusColor = if (item.status == ConsultStatus.WAITING) PharmTheme.colors.secondary else PharmTheme.colors.primary,
+                contentColor = PharmTheme.colors.surface
             )
         }
 
@@ -59,7 +55,7 @@ fun QuestionSection(item: ConsultItem) {
             text = item.title,
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
-            color = Black,
+            color = PharmTheme.colors.onSurface,
         )
 
         Spacer(modifier = Modifier.height(10.dp))
@@ -67,7 +63,7 @@ fun QuestionSection(item: ConsultItem) {
         Text(
             text = item.content,
             fontSize = 15.sp,
-            color = SecondFont,
+            color = PharmTheme.colors.secondFont,
             lineHeight = 20.sp
         )
 

--- a/features/home/src/main/java/com/moon/pharm/home/screen/HomeMainScreen.kt
+++ b/features/home/src/main/java/com/moon/pharm/home/screen/HomeMainScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -44,12 +43,7 @@ import com.moon.pharm.component_ui.model.TopBarAction
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
 import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
-import com.moon.pharm.component_ui.theme.OnSurface
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Secondary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.home.viewmodel.HomeViewModel
 
 @Composable
@@ -88,7 +82,7 @@ fun HomeMainScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .background(backgroundLight)
+                .background(PharmTheme.colors.background)
                 .verticalScroll(scrollState)
         ) {
             Column(
@@ -100,7 +94,7 @@ fun HomeMainScreen(
                     text = "${displayName}님, 건강 챙기세요!",
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
-                    color = OnSurface
+                    color = PharmTheme.colors.onSurface
                 )
 
                 PharmNotice()
@@ -132,10 +126,10 @@ fun PharmNotice() {
                 .height(130.dp)
                 .border(
                     width = 0.5.dp,
-                    color = Color(118, 118, 118).copy(alpha = 0.5f),
+                    color = PharmTheme.colors.placeholder,
                     shape = RoundedCornerShape(10.dp)
                 )
-                .background(White),
+                .background(PharmTheme.colors.surface),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             Row(
@@ -149,7 +143,7 @@ fun PharmNotice() {
                     modifier = Modifier
                         .padding(start = 20.dp, end = 10.dp)
                         .background(
-                            color = Secondary.copy(alpha = 0.2f),
+                            color = PharmTheme.colors.secondary.copy(alpha = 0.2f),
                             shape = RoundedCornerShape(100.dp)
                         )
                 ) {
@@ -170,7 +164,7 @@ fun PharmNotice() {
                         text = "점심약 복용 시간입니다",
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Normal,
-                        color = SecondFont
+                        color = PharmTheme.colors.secondFont
                     )
                 }
             }
@@ -181,7 +175,7 @@ fun PharmNotice() {
                 text = "총 2개 알림",
                 fontSize = 10.sp,
                 fontWeight = FontWeight.Medium,
-                color = Color(51, 51, 51)
+                color = PharmTheme.colors.onSurface.copy(alpha = 0.8f)
             )
         }
     }
@@ -195,7 +189,7 @@ fun RateOfUse() {
             .fillMaxWidth()
             .padding(top = 20.dp)
             .background(
-                color = Secondary.copy(alpha = 0.1f),
+                color = PharmTheme.colors.secondary.copy(alpha = 0.1f),
                 shape = RoundedCornerShape(10.dp)
             )
             .heightIn(min = 60.dp),
@@ -207,10 +201,9 @@ fun RateOfUse() {
                 .padding(10.dp)
                 .border(
                     width = 1.dp,
-                    color = Secondary,
+                    color = PharmTheme.colors.secondary,
                     shape = RoundedCornerShape(10.dp)
                 )
-//                .height(40.dp)
                 .width(80.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -224,7 +217,7 @@ fun RateOfUse() {
                 text = "95%",
                 fontSize = 14.sp,
                 fontWeight = FontWeight.SemiBold,
-                color = SecondFont
+                color = PharmTheme.colors.secondFont
             )
         }
         Column(
@@ -242,7 +235,7 @@ fun RateOfUse() {
                 text = "오전 8:00 아침약 복용 완료",
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Normal,
-                color = Color(118, 118, 118)
+                color = PharmTheme.colors.secondFont
             )
         }
     }
@@ -257,7 +250,7 @@ fun PharmSafety() {
             .padding(top = 20.dp)
             .heightIn(min = 140.dp)
             .background(
-                color = Primary,
+                color = PharmTheme.colors.primary,
                 shape = RoundedCornerShape(10.dp)
             ),
     ) {
@@ -270,7 +263,7 @@ fun PharmSafety() {
             Icon(
                 Icons.Outlined.VerifiedUser,
                 contentDescription = "verifiedUser",
-                tint = Color.White,
+                tint = PharmTheme.colors.surface,
                 modifier = Modifier.padding(start = 20.dp, end = 20.dp)
             )
             Column(
@@ -281,14 +274,14 @@ fun PharmSafety() {
                     text = "복용 전 약물 안전성을 확인하세요!",
                     fontSize = 14.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color.White
+                    color = PharmTheme.colors.surface
                 )
                 Text(
                     modifier = Modifier.padding(top = 10.dp),
                     text = "복용 중인 약물 간 상호작용(DDI) 위험을 점검하고 건강을 챙기세요.",
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Normal,
-                    color = Color(0xFFDDDDDD)
+                    color = PharmTheme.colors.surface.copy(alpha = 0.8f)
                 )
             }
         }
@@ -297,7 +290,7 @@ fun PharmSafety() {
                 .fillMaxWidth()
                 .padding(start = 65.dp, end = 20.dp, top = 12.dp, bottom = 16.dp)
                 .background(
-                    color = Color.White,
+                    color = PharmTheme.colors.surface,
                     shape = RoundedCornerShape(5.dp)
                 )
                 .padding(vertical = 4.dp),
@@ -315,7 +308,7 @@ fun PharmSafety() {
                 text = "안전성 바로 확인하기 >",
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Normal,
-                color = Primary,
+                color = PharmTheme.colors.primary,
                 modifier = Modifier
                     .padding(horizontal = 4.dp)
                     .clickable { }

--- a/features/prescription/src/main/java/com/moon/pharm/prescription/screen/CameraPreviewScreen.kt
+++ b/features/prescription/src/main/java/com/moon/pharm/prescription/screen/CameraPreviewScreen.kt
@@ -22,7 +22,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.prescription.ocr.TextRecognitionAnalyzer
 import com.moon.pharm.prescription.viewmodel.PrescriptionUiEvent
 import com.moon.pharm.prescription.viewmodel.PrescriptionViewModel
@@ -106,7 +106,7 @@ fun CameraPreviewScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(32.dp),
-            color = White
+            color = PharmTheme.colors.surface
         )
     }
 }

--- a/features/prescription/src/main/java/com/moon/pharm/prescription/screen/PrescriptionScreen.kt
+++ b/features/prescription/src/main/java/com/moon/pharm/prescription/screen/PrescriptionScreen.kt
@@ -37,8 +37,7 @@ import androidx.navigation.NavController
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
 import com.moon.pharm.component_ui.component.progress.CircularProgressBar
 import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.prescription.viewmodel.PrescriptionUiEvent
 import com.moon.pharm.prescription.viewmodel.PrescriptionViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -136,7 +135,7 @@ fun PrescriptionScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Black.copy(alpha = 0.5f))
+                .background(PharmTheme.colors.onSurface.copy(alpha = 0.5f))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -149,7 +148,7 @@ fun PrescriptionScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = "처방전을 분석하고 있어요...",
-                    color = White,
+                    color = PharmTheme.colors.surface,
                     fontWeight = FontWeight.Bold
                 )
             }

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/LoginScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/LoginScreen.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
 import com.moon.pharm.component_ui.component.snackbar.CustomSnackbar
 import com.moon.pharm.component_ui.component.snackbar.SnackbarType
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.auth.mapper.asString
 import com.moon.pharm.profile.auth.model.LoginUiMessage
@@ -79,7 +79,7 @@ fun LoginScreenContent(
     onSignUpClick: () -> Unit
 ) {
     Scaffold(
-        containerColor = White,
+        containerColor = PharmTheme.colors.surface,
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { data ->
                 CustomSnackbar(snackbarData = data, type = SnackbarType.ERROR)

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/SignUpScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/SignUpScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.auth.mapper.asString
 import com.moon.pharm.profile.auth.model.SignUpStep
@@ -111,7 +111,7 @@ fun SignUpScreenContent(
     onNextClick: () -> Unit
 ) {
     Scaffold(
-        containerColor = White,
+        containerColor = PharmTheme.colors.surface,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
         Column(

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/component/LoginHeader.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/component/LoginHeader.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 @Composable
@@ -34,7 +34,7 @@ fun LoginHeader() {
             text = stringResource(R.string.login_app_title),
             fontSize = 28.sp,
             fontWeight = FontWeight.ExtraBold,
-            color = Primary
+            color = PharmTheme.colors.primary
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/component/SignUpHeader.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/component/SignUpHeader.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 @Composable
@@ -34,7 +34,7 @@ fun SignUpHeader() {
             text = stringResource(R.string.signup_button_complete),
             fontSize = 20.sp,
             fontWeight = FontWeight.ExtraBold,
-            color = Primary
+            color = PharmTheme.colors.primary
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/EmailPasswordSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/EmailPasswordSection.kt
@@ -14,13 +14,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.profile.R
 
@@ -46,7 +44,7 @@ fun EmailPasswordSection(
                     modifier = Modifier
                         .padding(10.dp)
                         .background(
-                            color = if (isEmailChecking || isAvailable == true) Color.Gray else Primary,
+                            color = if (isEmailChecking || isAvailable == true) PharmTheme.colors.placeholder else PharmTheme.colors.primary,
                             shape = RoundedCornerShape(5.dp)
                         )
                         .clickableSingle(enabled = !isEmailChecking && isAvailable != true) {
@@ -58,7 +56,7 @@ fun EmailPasswordSection(
                     if (isEmailChecking) {
                         androidx.compose.material3.CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),
-                            color = White,
+                            color = PharmTheme.colors.surface,
                             strokeWidth = 2.dp
                         )
                     } else {
@@ -68,7 +66,7 @@ fun EmailPasswordSection(
                                 else stringResource(R.string.signup_email_check_button),
                             fontSize = 12.sp,
                             fontWeight = FontWeight.Bold,
-                            color = White
+                            color = PharmTheme.colors.surface
                         )
                     }
                 }
@@ -77,14 +75,14 @@ fun EmailPasswordSection(
         if (isAvailable == true) {
             Text(
                 stringResource(R.string.signup_email_available),
-                color = Primary,
+                color = PharmTheme.colors.primary,
                 fontSize = 12.sp,
                 modifier = Modifier.padding(top = 8.dp, start = 8.dp)
             )
         } else if (isAvailable == false) {
             Text(
                 stringResource(R.string.signup_email_duplicated),
-                color = Color.Red,
+                color = PharmTheme.colors.error,
                 fontSize = 12.sp,
                 modifier = Modifier.padding(top = 8.dp, start = 8.dp)
             )

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/LoginFooterSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/LoginFooterSection.kt
@@ -12,8 +12,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Secondary
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.profile.R
 
@@ -28,12 +27,12 @@ fun LoginFooterSection(
     ) {
         Text(
             text = stringResource(R.string.login_prompt_no_account),
-            color = SecondFont,
+            color = PharmTheme.colors.secondFont,
             fontSize = 12.sp
         )
         Text(
             text = stringResource(R.string.login_action_sign_up),
-            color = Secondary,
+            color = PharmTheme.colors.secondary,
             fontWeight = FontWeight.Bold,
             fontSize = 12.sp,
             modifier = Modifier

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/NickNameSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/NickNameSection.kt
@@ -19,11 +19,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.profile.R
 
@@ -42,7 +42,7 @@ fun NickNameSection(
             modifier = Modifier
                 .size(100.dp)
                 .clip(CircleShape)
-                .background(Color.LightGray)
+                .background(PharmTheme.colors.placeholder)
                 .clickableSingle { onImageClick() },
             contentAlignment = Alignment.Center
         ) {
@@ -58,7 +58,7 @@ fun NickNameSection(
                     imageVector = Icons.Default.Person,
                     contentDescription = null,
                     modifier = Modifier.size(50.dp),
-                    tint = Color.Gray
+                    tint = PharmTheme.colors.placeholder
                 )
             }
         }

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/SignUpButtonSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/SignUpButtonSection.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
-import com.moon.pharm.component_ui.theme.Secondary
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.auth.model.SignUpStep
@@ -41,6 +41,6 @@ fun SignUpButtonSection(
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = 24.dp),
-        containerColor = Secondary
+        containerColor = PharmTheme.colors.secondary
     )
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/UserTypeSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/auth/screen/section/UserTypeSection.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.util.labelRes
 
@@ -62,7 +62,7 @@ fun UserTypeRow(
                 onClick = onSelect,
                 role = Role.RadioButton
             )
-            .border(1.dp, SecondFont, RoundedCornerShape(10.dp))
+            .border(1.dp, PharmTheme.colors.secondFont, RoundedCornerShape(10.dp))
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHistoryScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHistoryScreen.kt
@@ -23,8 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moon.pharm.component_ui.component.bar.PharmTopBar
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayString
 import com.moon.pharm.component_ui.util.toQueryString
 import com.moon.pharm.profile.medication.screen.component.HistoryRecordItem
@@ -95,7 +94,7 @@ fun MedicationHistoryContent(
                 modifier = Modifier.padding(horizontal = 20.dp),
                 fontWeight = FontWeight.Bold,
                 fontSize = 18.sp,
-                color = Black
+                color = PharmTheme.colors.onSurface
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -112,7 +111,7 @@ fun MedicationHistoryContent(
                         Text(
                             text = "복약 기록이 없습니다.",
                             modifier = Modifier.padding(top = 20.dp),
-                            color = SecondFont
+                            color = PharmTheme.colors.secondFont
                         )
                     }
                 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
@@ -22,10 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Success
-import com.moon.pharm.component_ui.theme.SuccessContainer
-import com.moon.pharm.component_ui.theme.Warning
-import com.moon.pharm.component_ui.theme.WarningContainer
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.model.HistoryRecordUiModel
 
@@ -35,8 +32,8 @@ fun HistoryRecordItem(
     onRecordClick: () -> Unit
 ) {
     val record = uiModel.record
-    val borderColor = if (record.isTaken) Success else Warning
-    val backgroundColor = if (record.isTaken) SuccessContainer else WarningContainer
+    val borderColor = if (record.isTaken) PharmTheme.colors.success else PharmTheme.colors.warning
+    val backgroundColor = if (record.isTaken) PharmTheme.colors.successContainer else PharmTheme.colors.warningContainer
 
     Row(
         modifier = Modifier

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationAlarmOptionsCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationAlarmOptionsCard.kt
@@ -12,8 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.viewmodel.MedicationFormState
 import com.moon.pharm.profile.medication.viewmodel.MedicationUiEvent
@@ -27,8 +26,8 @@ fun MedicationAlarmOptionsCard(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(White, RoundedCornerShape(12.dp))
-            .border(0.5.dp, tertiaryLight, RoundedCornerShape(12.dp))
+            .background(PharmTheme.colors.surface, RoundedCornerShape(12.dp))
+            .border(0.5.dp, PharmTheme.colors.tertiary, RoundedCornerShape(12.dp))
             .padding(10.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationCheckButton.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationCheckButton.kt
@@ -21,9 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.primaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 /**
@@ -37,10 +35,10 @@ fun MedicationCheckButton(
     OutlinedButton(
         onClick = onClick,
         shape = RoundedCornerShape(10.dp),
-        border = if (isTaken) null else BorderStroke(1.dp, primaryLight),
+        border = if (isTaken) null else BorderStroke(1.dp, PharmTheme.colors.primary),
         colors = ButtonDefaults.outlinedButtonColors(
-            containerColor = if (isTaken) Primary else Color.Transparent,
-            contentColor = if (isTaken) White else primaryLight
+            containerColor = if (isTaken) PharmTheme.colors.primary else Color.Transparent,
+            contentColor = if (isTaken) PharmTheme.colors.surface else PharmTheme.colors.primary
         ),
         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
         modifier = Modifier.height(36.dp)
@@ -48,7 +46,7 @@ fun MedicationCheckButton(
         Icon(
             imageVector = if (isTaken) Icons.Filled.CheckCircle else Icons.Outlined.RadioButtonUnchecked,
             contentDescription = null,
-            tint = if (isTaken) White else primaryLight,
+            tint = if (isTaken) PharmTheme.colors.surface else PharmTheme.colors.primary,
             modifier = Modifier.size(16.dp)
         )
         Spacer(Modifier.width(4.dp))

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationCreateContent.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationCreateContent.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.component.button.PharmPrimaryButton
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.screen.section.MedicationAlarmSection
 import com.moon.pharm.profile.medication.screen.section.MedicationInfoSection
@@ -35,7 +35,7 @@ fun MedicationCreateContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
             .verticalScroll(scrollState)
             .padding(horizontal = 24.dp, vertical = 20.dp)
     ) {

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationGroupItem.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationGroupItem.kt
@@ -15,11 +15,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayTimeString
 import com.moon.pharm.domain.model.medication.MedicationTimeGroup
 import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
@@ -40,14 +39,14 @@ fun MedicationGroupItem(
                 modifier = Modifier
                     .size(8.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFFFFC107))
+                    .background(PharmTheme.colors.warning)
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(
                 text = displayTime ?: "",
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Bold,
-                color = SecondFont
+                color = PharmTheme.colors.secondFont
             )
         }
 

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationHomeContent.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationHomeContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.component.bar.PharmPrimaryTabRow
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.medication.MedicationTimeGroup
 import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
 import com.moon.pharm.profile.medication.model.MedicationPrimaryTab
@@ -32,7 +32,7 @@ fun MedicationHomeContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundLight)
+            .background(PharmTheme.colors.background)
     ) {
         PharmPrimaryTabRow(
             selectedTabIndex = selectedTab.index,

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
 
 @Composable
@@ -30,8 +28,8 @@ fun MedicationItemCard(
 ) {
     Card(
         colors = CardDefaults.cardColors(
-            containerColor = White,
-            contentColor = Primary
+            containerColor = PharmTheme.colors.surface,
+            contentColor = PharmTheme.colors.primary
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = RoundedCornerShape(12.dp),
@@ -50,19 +48,19 @@ fun MedicationItemCard(
                         text = item.name,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Color.Black
+                        color = PharmTheme.colors.onSurface
                     )
                     Text(
                         text = " · ${item.type.label}",
                         fontSize = 13.sp,
-                        color = SecondFont
+                        color = PharmTheme.colors.secondFont
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = "${item.mealTiming.label} · ${item.repeatType.label}",
                     fontSize = 13.sp,
-                    color = SecondFont
+                    color = PharmTheme.colors.secondFont
                 )
             }
 

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationProgressCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationProgressCard.kt
@@ -21,10 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.tertiaryLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,7 +30,7 @@ fun MedicationProgressCard(total: Int, completed: Int) {
     val progressValue = if (total > 0) completed.toFloat() / total.toFloat() else 0f
 
     Card(
-        colors = CardDefaults.cardColors(containerColor = White),
+        colors = CardDefaults.cardColors(containerColor = PharmTheme.colors.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = RoundedCornerShape(12.dp),
         modifier = Modifier.fillMaxWidth()
@@ -54,7 +51,7 @@ fun MedicationProgressCard(total: Int, completed: Int) {
                     ),
                     fontSize = 15.sp,
                     fontWeight = FontWeight.Bold,
-                    color = Color.Black
+                    color = PharmTheme.colors.onSurface
                 )
             }
 
@@ -65,8 +62,8 @@ fun MedicationProgressCard(total: Int, completed: Int) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(8.dp),
-                color = Primary,
-                trackColor = tertiaryLight,
+                color = PharmTheme.colors.primary,
+                trackColor = PharmTheme.colors.tertiary,
                 gapSize = 0.dp,
             )
 
@@ -76,7 +73,7 @@ fun MedicationProgressCard(total: Int, completed: Int) {
                 // TODO: 실제 데이터 기반 계산으로 변경
                 text = "이번 주 복용 준수율 94%",
                 fontSize = 13.sp,
-                color = SecondFont
+                color = PharmTheme.colors.secondFont
             )
         }
     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationSwitchRow.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationSwitchRow.kt
@@ -28,8 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.dialog.PharmInfoDialog
 import com.moon.pharm.component_ui.component.toggle.CustomSwitch
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.SecondFont
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 @Composable
@@ -52,9 +51,9 @@ fun MedicationSwitchRow(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Column {
-                Text(text = title, fontSize = 14.sp, color = Black, fontWeight = FontWeight.Medium)
+                Text(text = title, fontSize = 14.sp, color = PharmTheme.colors.onSurface, fontWeight = FontWeight.Medium)
                 if (description != null) {
-                    Text(text = description, fontSize = 12.sp, color = SecondFont)
+                    Text(text = description, fontSize = 12.sp, color = PharmTheme.colors.secondFont)
                 }
             }
 
@@ -63,7 +62,7 @@ fun MedicationSwitchRow(
                 Icon(
                     imageVector = Icons.Default.Info,
                     contentDescription = stringResource(R.string.medication_info),
-                    tint = SecondFont,
+                    tint = PharmTheme.colors.secondFont,
                     modifier = Modifier
                         .size(20.dp)
                         .clip(CircleShape)

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationTypeSelector.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationTypeSelector.kt
@@ -15,10 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Tertiary
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.domain.model.medication.MedicationType
 
@@ -40,7 +37,7 @@ fun MedicationTypeSelector(
                     .weight(1f)
                     .height(32.dp)
                     .background(
-                        color = if (isSelected) Primary else Tertiary,
+                        color = if (isSelected) PharmTheme.colors.primary else PharmTheme.colors.tertiary,
                         shape = RoundedCornerShape(6.dp)
                     )
                     .clickableSingle { onTypeSelected(type) },
@@ -50,7 +47,7 @@ fun MedicationTypeSelector(
                     text = type.label,
                     fontSize = 13.sp,
                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
-                    color = if (isSelected) White else SecondFont
+                    color = if (isSelected) PharmTheme.colors.surface else PharmTheme.colors.secondFont
                 )
             }
         }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/PeriodInputSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/PeriodInputSection.kt
@@ -15,13 +15,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.card.DateSettingCard
 import com.moon.pharm.component_ui.component.dialog.DatePickerModal
 import com.moon.pharm.component_ui.component.toggle.CustomSwitch
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayDateString
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.viewmodel.MedicationUiEvent
@@ -96,7 +96,7 @@ fun PeriodInputSection(
         Text(
             text = stringResource(R.string.medication_no_end_date),
             fontSize = 12.sp,
-            color = Color.Black
+            color = PharmTheme.colors.onSurface
         )
         Spacer(modifier = Modifier.width(4.dp))
         CustomSwitch(

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/HistoryCalendarSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/HistoryCalendarSection.kt
@@ -30,12 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Black
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Success
-import com.moon.pharm.component_ui.theme.Warning
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toDisplayString
 import com.moon.pharm.component_ui.util.toQueryString
 import com.moon.pharm.profile.medication.model.HistoryRecordUiModel
@@ -53,7 +48,7 @@ fun HistoryCalendarSection(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(White)
+            .background(PharmTheme.colors.surface)
             .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         CalendarHeader(
@@ -90,7 +85,7 @@ private fun CalendarHeader(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                 contentDescription = "이전 달",
-                tint = Black
+                tint = PharmTheme.colors.onSurface
             )
         }
 
@@ -98,14 +93,14 @@ private fun CalendarHeader(
             text = currentMonth.toDisplayString(),
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            color = Black
+            color = PharmTheme.colors.onSurface
         )
 
         IconButton(onClick = { onMonthChanged(currentMonth.plusMonths(1)) }) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "다음 달",
-                tint = Black
+                tint = PharmTheme.colors.onSurface
             )
         }
     }
@@ -120,7 +115,7 @@ private fun DayOfWeekHeader() {
                 text = day,
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium
             )
@@ -175,8 +170,8 @@ private fun DayCell(
 ) {
     val dotColor = when {
         dailyRecords.isEmpty() -> Color.Transparent
-        dailyRecords.all { it.record.isTaken } -> Success
-        dailyRecords.any { !it.record.isTaken } -> Warning
+        dailyRecords.all { it.record.isTaken } -> PharmTheme.colors.success
+        dailyRecords.any { !it.record.isTaken } -> PharmTheme.colors.warning
         else -> Color.Transparent
     }
 
@@ -185,7 +180,7 @@ private fun DayCell(
             .aspectRatio(1f)
             .padding(4.dp)
             .clip(CircleShape)
-            .background(if (isSelected) Primary else Color.Transparent)
+            .background(if (isSelected) PharmTheme.colors.primary else Color.Transparent)
             .clickable { onClick() },
         contentAlignment = Alignment.Center
     ) {
@@ -195,7 +190,7 @@ private fun DayCell(
         ) {
             Text(
                 text = day.toString(),
-                color = if (isSelected) White else Black,
+                color = if (isSelected) PharmTheme.colors.surface else PharmTheme.colors.onSurface,
                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                 fontSize = 14.sp
             )
@@ -206,7 +201,7 @@ private fun DayCell(
                     modifier = Modifier
                         .size(4.dp)
                         .clip(CircleShape)
-                        .background(if (isSelected) White else dotColor)
+                        .background(if (isSelected) PharmTheme.colors.surface else dotColor)
                 )
             }
         }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationAlarmSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationAlarmSection.kt
@@ -15,15 +15,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.card.TimeSettingCard
 import com.moon.pharm.component_ui.component.dialog.TimePickerDialog
-import com.moon.pharm.component_ui.theme.Secondary
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.toMinuteTimeUiString
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.screen.component.AlarmOptionSelector
@@ -44,15 +42,15 @@ fun MedicationAlarmSection(
     Column(
         modifier = Modifier
             .wrapContentSize()
-            .background(backgroundLight)
-            .background(Secondary.copy(alpha = 0.1f), RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.background)
+            .background(PharmTheme.colors.secondary.copy(alpha = 0.1f), RoundedCornerShape(10.dp))
             .padding(10.dp)
     ) {
         Text(
             text = stringResource(R.string.medication_setting_alarm),
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
-            color = Color.Black,
+            color = PharmTheme.colors.onSurface,
             modifier = Modifier.padding(bottom = 12.dp)
         )
 

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationInfoSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationInfoSection.kt
@@ -19,12 +19,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.moon.pharm.component_ui.component.input.PrimaryTextField
-import com.moon.pharm.component_ui.theme.Secondary
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.screen.component.PeriodInputSection
 import com.moon.pharm.profile.medication.viewmodel.MedicationFormState
@@ -41,8 +39,8 @@ fun MedicationInfoSection(
     Column(
         modifier = Modifier
             .wrapContentSize()
-            .background(backgroundLight)
-            .background(Secondary.copy(alpha = 0.1f), RoundedCornerShape(10.dp))
+            .background(PharmTheme.colors.background)
+            .background(PharmTheme.colors.surface.copy(alpha = 0.1f), RoundedCornerShape(10.dp))
             .padding(10.dp)
     ) {
         if (!isSingleMode) {
@@ -81,7 +79,7 @@ fun MedicationInfoSection(
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = "삭제",
-                            tint = Color.Gray
+                            tint = PharmTheme.colors.placeholder
                         )
                     }
                 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/MyPageScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/MyPageScreen.kt
@@ -33,7 +33,7 @@ import com.moon.pharm.component_ui.component.bar.PharmTopBar
 import com.moon.pharm.component_ui.model.TopBarAction
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.User
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.BuildConfig
@@ -223,7 +223,7 @@ fun MyPageScreenPreviewSuccess() {
     )
 
     MaterialTheme {
-        Surface(color = backgroundLight) {
+        Surface(color = PharmTheme.colors.background) {
             MyPageScreen(
                 uiState = MyPageUiState(
                     isLoading = false,

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/EditNicknameDialog.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/EditNicknameDialog.kt
@@ -11,13 +11,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 import com.moon.pharm.component_ui.R as UiR
 
@@ -31,9 +28,9 @@ fun EditNicknameDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = backgroundLight,
-        titleContentColor = Color.Black,
-        textContentColor = Color.Black,
+        containerColor = PharmTheme.colors.background,
+        titleContentColor = PharmTheme.colors.onSurface,
+        textContentColor = PharmTheme.colors.onSurface,
         shape = RoundedCornerShape(10.dp),
         text = {
             OutlinedTextField(
@@ -42,11 +39,11 @@ fun EditNicknameDialog(
                 label = { Text(stringResource(R.string.signup_nickname_label)) },
                 singleLine = true,
                 colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = Primary,
-                    focusedLabelColor = Primary,
-                    cursorColor = Primary,
-                    unfocusedContainerColor = White,
-                    focusedContainerColor = White
+                    focusedBorderColor = PharmTheme.colors.primary,
+                    focusedLabelColor = PharmTheme.colors.primary,
+                    cursorColor = PharmTheme.colors.primary,
+                    unfocusedContainerColor = PharmTheme.colors.surface,
+                    focusedContainerColor = PharmTheme.colors.surface
                 )
             )
         },
@@ -62,7 +59,7 @@ fun EditNicknameDialog(
             ) {
                 Text(
                     text = stringResource(UiR.string.common_confirm),
-                    color = Primary,
+                    color = PharmTheme.colors.primary,
                     fontWeight = FontWeight.Bold
                 )
             }
@@ -71,7 +68,7 @@ fun EditNicknameDialog(
             TextButton(onClick = onDismiss) {
                 Text(
                     text = stringResource(UiR.string.common_cancel),
-                    color = Primary
+                    color = PharmTheme.colors.primary
                 )
             }
         }

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageFooterSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageFooterSection.kt
@@ -27,11 +27,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.button.PharmOutlinedButton
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Tertiary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.profile.R
 
 @Composable
@@ -44,7 +40,7 @@ fun MyPageFooterSection(
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Card(
-            colors = CardDefaults.cardColors(containerColor = White),
+            colors = CardDefaults.cardColors(containerColor = PharmTheme.colors.surface),
             shape = RoundedCornerShape(16.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -54,7 +50,7 @@ fun MyPageFooterSection(
                     onClick = onTermsClick
                 )
                 HorizontalDivider(
-                    color = backgroundLight,
+                    color = PharmTheme.colors.background,
                     thickness = 1.dp,
                     modifier = Modifier.padding(horizontal = 20.dp)
                 )
@@ -71,7 +67,7 @@ fun MyPageFooterSection(
             text = stringResource(R.string.mypage_app_version_format, appVersion),
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
-            color = SecondFont,
+            color = PharmTheme.colors.secondFont,
             fontSize = 12.sp
         )
 
@@ -92,7 +88,7 @@ fun MyPageFooterSection(
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
             Text(
                 text = stringResource(R.string.mypage_withdraw),
-                color = SecondFont,
+                color = PharmTheme.colors.secondFont,
                 fontSize = 13.sp,
                 textDecoration = TextDecoration.Underline,
                 modifier = Modifier.clickable { onWithdrawClick() }
@@ -110,11 +106,11 @@ private fun SimpleLinkItem(text: String, onClick: () -> Unit) {
             .padding(18.dp),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(text, fontSize = 14.sp, color = Primary)
+        Text(text, fontSize = 14.sp, color = PharmTheme.colors.primary)
         Icon(
             Icons.AutoMirrored.Filled.KeyboardArrowRight,
             contentDescription = null,
-            tint = Tertiary
+            tint = PharmTheme.colors.tertiary
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageMenuSection.kt
@@ -26,11 +26,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.Tertiary
-import com.moon.pharm.component_ui.theme.White
-import com.moon.pharm.component_ui.theme.backgroundLight
+import com.moon.pharm.component_ui.theme.PharmTheme
 
 @Composable
 fun MyPageMenuSection(
@@ -41,11 +37,11 @@ fun MyPageMenuSection(
         Text(
             text = title,
             fontSize = 13.sp,
-            color = SecondFont,
+            color = PharmTheme.colors.secondFont,
             modifier = Modifier.padding(bottom = 8.dp, start = 4.dp)
         )
         Card(
-            colors = CardDefaults.cardColors(containerColor = White),
+            colors = CardDefaults.cardColors(containerColor = PharmTheme.colors.surface),
             shape = RoundedCornerShape(16.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -54,7 +50,7 @@ fun MyPageMenuSection(
                     MenuRowItem(item)
                     if (index < items.lastIndex) {
                         HorizontalDivider(
-                            color = backgroundLight,
+                            color = PharmTheme.colors.background,
                             thickness = 1.dp,
                             modifier = Modifier.padding(horizontal = 20.dp)
                         )
@@ -78,13 +74,13 @@ private fun MenuRowItem(item: MyPageMenuItemData) {
             modifier = Modifier
                 .size(36.dp)
                 .clip(CircleShape)
-                .background(Tertiary),
+                .background(PharmTheme.colors.tertiary),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = item.icon,
                 contentDescription = null,
-                tint = Primary,
+                tint = PharmTheme.colors.primary,
                 modifier = Modifier.size(20.dp)
             )
         }
@@ -99,7 +95,7 @@ private fun MenuRowItem(item: MyPageMenuItemData) {
                 text = item.title,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium,
-                color = Primary
+                color = PharmTheme.colors.primary
             )
 
             if (!item.count.isNullOrEmpty()) {
@@ -108,7 +104,7 @@ private fun MenuRowItem(item: MyPageMenuItemData) {
                     text = item.count,
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Normal,
-                    color = SecondFont
+                    color = PharmTheme.colors.secondFont
                 )
             }
         }
@@ -116,7 +112,7 @@ private fun MenuRowItem(item: MyPageMenuItemData) {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
             contentDescription = null,
-            tint = Tertiary
+            tint = PharmTheme.colors.tertiary
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageProfileCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/mypage/screen/component/MyPageProfileCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -31,9 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.moon.pharm.component_ui.component.button.PharmOutlinedButton
-import com.moon.pharm.component_ui.theme.Primary
-import com.moon.pharm.component_ui.theme.SecondFont
-import com.moon.pharm.component_ui.theme.White
+import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.domain.model.auth.User
 import com.moon.pharm.domain.model.auth.UserType
 import com.moon.pharm.profile.R
@@ -49,7 +46,7 @@ fun MyPageProfileCard(
         stringResource(R.string.mypage_general_member)
 
     Card(
-        colors = CardDefaults.cardColors(containerColor = White),
+        colors = CardDefaults.cardColors(containerColor = PharmTheme.colors.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = RoundedCornerShape(16.dp),
         modifier = Modifier.fillMaxWidth()
@@ -60,7 +57,7 @@ fun MyPageProfileCard(
                     modifier = Modifier
                         .size(60.dp)
                         .clip(CircleShape)
-                        .background(Color.LightGray),
+                        .background(PharmTheme.colors.placeholder),
                     contentAlignment = Alignment.Center
                 ) {
                     if (!user.profileImageUrl.isNullOrEmpty()) {
@@ -71,7 +68,7 @@ fun MyPageProfileCard(
                             modifier = Modifier.fillMaxSize()
                         )
                     } else {
-                        Icon(Icons.Default.Face, contentDescription = null, tint = White)
+                        Icon(Icons.Default.Face, contentDescription = null, tint = PharmTheme.colors.surface)
                     }
                 }
 
@@ -82,9 +79,9 @@ fun MyPageProfileCard(
                         text = "${user.nickName}${stringResource(R.string.mypage_user_suffix)}",
                         fontSize = 20.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Primary
+                        color = PharmTheme.colors.primary
                     )
-                    Text(text = userTypeLabel, fontSize = 14.sp, color = SecondFont)
+                    Text(text = userTypeLabel, fontSize = 14.sp, color = PharmTheme.colors.secondFont)
                 }
             }
 


### PR DESCRIPTION
- `PharmColors.kt` 내 원시 색상(Primitive Color)을 `private`으로 캡슐화하고, 시맨틱 색상 기반의 `PharmColorPalette` 데이터 클래스 도입
- `CompositionLocalProvider`를 통해 `LocalPharmColors` 및 `LocalContentColor`를 주입하여 하위 컴포넌트의 테마 접근성 및 타입 안정성 확보
- 커스텀 팔레트를 Material3 `ColorScheme`으로 변환하는 `toMaterialColorScheme()` 확장 함수를 추가하여 Material 컴포넌트와의 호환성 보장
- 공통 UI 및 주요 도메인 화면(Home, Consult, Profile 등)에 남아있던 하드코딩된 색상(Hex, RGB, 전역 변수)을 모두 `PharmTheme.colors` 참조로 전면 마이그레이션
- `ConsultStatus` 매퍼(Mapper) 함수에 `@Composable` 어노테이션을 추가하여 Compose 생명주기 내에서 안전하게 테마를 참조하도록 수정
- 향후 다크 모드(Dark Mode) 및 브랜드 컬러 변경 시 단일 진입점(PharmTheme)에서 유연하게 대응할 수 있는 아키텍처 기반 마련

Close #85