### PR TITLE
refactor(component-ui): 공통 리스트 컴포넌트(PharmListItem) 확장 및 일괄 적용

### DIFF
--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmListItem.kt
@@ -1,6 +1,7 @@
 package com.moon.pharm.component_ui.component.item
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,8 +24,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
@@ -34,6 +37,9 @@ import com.moon.pharm.component_ui.util.ThemePreviews
 @Composable
 fun PharmListItem(
     modifier: Modifier = Modifier,
+    containerColor: Color = PharmTheme.colors.surface,
+    borderColor: Color? = null,
+    contentPadding: Dp = 16.dp,
     leading: @Composable (() -> Unit)? = null,
     headline: String,
     subhead: String? = null,
@@ -41,13 +47,18 @@ fun PharmListItem(
     trailing: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null
 ) {
+    val borderModifier = if (borderColor != null) {
+        Modifier.border(1.dp, borderColor, RoundedCornerShape(10.dp))
+    } else Modifier
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
-            .background(PharmTheme.colors.surface)
+            .then(borderModifier)
+            .background(containerColor)
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-            .padding(16.dp),
+            .padding(contentPadding),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (leading != null) {

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacistListItem.kt
@@ -2,13 +2,8 @@ package com.moon.pharm.component_ui.component.item
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,15 +39,9 @@ fun PharmacistListItem(
 ) {
     val textToDisplay = btnText ?: stringResource(R.string.btn_select)
 
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+    PharmListItem(
+        modifier = modifier,
+        leading = {
             Box(
                 modifier = Modifier
                     .size(48.dp)
@@ -68,38 +57,27 @@ fun PharmacistListItem(
                     modifier = Modifier.size(24.dp)
                 )
             }
-            Spacer(modifier = Modifier.width(10.dp))
-            Column {
+        },
+        headline = pharmacist.name,
+        subhead = pharmacist.bio,
+        trailing = {
+            Button(
+                onClick = { onSelect(pharmacist) },
+                colors = ButtonDefaults.buttonColors(containerColor = PharmTheme.colors.primary),
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier
+                    .height(36.dp)
+                    .width(64.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
                 Text(
-                    text = pharmacist.name,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = PharmTheme.colors.onSurface
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = pharmacist.bio,
+                    text = textToDisplay,
                     fontSize = 13.sp,
-                    color = PharmTheme.colors.secondFont
+                    fontWeight = FontWeight.Medium
                 )
             }
         }
-        Button(
-            onClick = { onSelect(pharmacist) },
-            colors = ButtonDefaults.buttonColors(containerColor = PharmTheme.colors.primary),
-            shape = RoundedCornerShape(8.dp),
-            modifier = Modifier
-                .height(36.dp)
-                .width(64.dp),
-            contentPadding = PaddingValues(0.dp)
-        ) {
-            Text(
-                text = textToDisplay,
-                fontSize = 13.sp,
-                fontWeight = FontWeight.Medium
-            )
-        }
-    }
+    )
 }
 
 @ThemePreviews

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/item/PharmacyListItem.kt
@@ -1,28 +1,16 @@
 package com.moon.pharm.component_ui.component.item
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.PharmacyListPreviewProvider
@@ -35,36 +23,20 @@ fun PharmacyListItem(
     onClick: (Pharmacy) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick(pharmacy) }
-            .background(PharmTheme.colors.surface, RoundedCornerShape(10.dp))
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = Icons.Default.LocationOn,
-            contentDescription = null,
-            tint = PharmTheme.colors.primary,
-            modifier = Modifier.size(24.dp)
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column {
-            Text(
-                text = pharmacy.name,
-                fontWeight = FontWeight.Bold,
-                fontSize = 15.sp,
-                color = PharmTheme.colors.onSurface
+    PharmListItem(
+        modifier = modifier,
+        onClick = { onClick(pharmacy) },
+        leading = {
+            Icon(
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = null,
+                tint = PharmTheme.colors.primary,
+                modifier = Modifier.size(24.dp)
             )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = pharmacy.address,
-                color = PharmTheme.colors.secondFont,
-                fontSize = 13.sp
-            )
-        }
-    }
+        },
+        headline = pharmacy.name,
+        subhead = pharmacy.address
+    )
 }
 
 @ThemePreviews

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultItemCard.kt
@@ -1,34 +1,23 @@
 package com.moon.pharm.consult.screen.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.StatusBadge
+import com.moon.pharm.component_ui.component.item.PharmListItem
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
-import com.moon.pharm.component_ui.util.clickableSingle
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.mapper.toBackgroundColor
@@ -41,80 +30,65 @@ fun ConsultItemCard(
     item: ConsultItem,
     currentUserId: String?,
     isPharmacist: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val isSecret = !item.isPublic
     val isOwner = !currentUserId.isNullOrBlank() && item.userId == currentUserId
     val isAssignedPharmacist = isPharmacist && item.pharmacistId == currentUserId
     val hasPermission = !isSecret || isOwner || isAssignedPharmacist
 
-    ElevatedCard(
-        colors = CardDefaults.elevatedCardColors(containerColor = PharmTheme.colors.surface),
-        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickableSingle { onClick() }
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (isSecret) {
-                        Icon(
-                            imageVector = Icons.Default.Lock,
-                            contentDescription = stringResource(R.string.consult_secret_icon_desc),
-                            tint = if (hasPermission) PharmTheme.colors.primary else PharmTheme.colors.secondFont,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                    }
+    val displayTitle = if (hasPermission) item.title else stringResource(R.string.consult_secret_hidden_title)
 
-                    Text(
-                        text = if (hasPermission) item.title else stringResource(R.string.consult_secret_hidden_title),
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = if (hasPermission) PharmTheme.colors.primary else PharmTheme.colors.secondFont,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        lineHeight = 20.sp
-                    )
-                }
-                Spacer(modifier = Modifier.height(6.dp))
-
-                Text(
-                    text = "${item.nickName} • ${item.createdAt.toDisplayDateTimeString()}",
-                    fontSize = 12.sp,
-                    color = PharmTheme.colors.secondFont
+    PharmListItem(
+        modifier = modifier,
+        onClick = onClick,
+        leading = if (isSecret) {
+            {
+                Icon(
+                    imageVector = Icons.Default.Lock,
+                    contentDescription = stringResource(R.string.consult_secret_icon_desc),
+                    tint = if (hasPermission) PharmTheme.colors.primary else PharmTheme.colors.placeholder,
+                    modifier = Modifier.size(20.dp)
                 )
             }
-
-            Spacer(modifier = Modifier.width(10.dp))
-
+        } else null,
+        headline = displayTitle,
+        subhead = "${item.nickName} • ${item.createdAt.toDisplayDateTimeString()}",
+        trailing = {
             StatusBadge(
                 text = item.status.label,
                 statusColor = item.status.toBackgroundColor(),
                 contentColor = item.status.toTextColor()
             )
         }
-    }
+    )
 }
 
 @ThemePreviews
 @Composable
 private fun ConsultItemCardPreview() {
     PharmMasterTheme {
-        Box(modifier = Modifier.padding(16.dp)) {
-            ConsultItemCard(
-                item = ConsultItem(id = "1", userId = "u1", pharmacistId = "p1", nickName = "사용자", title = "공개 상담", content = "...", isPublic = true, status = ConsultStatus.WAITING, createdAt = System.currentTimeMillis()),
-                currentUserId = "u1",
-                isPharmacist = false,
-                onClick = {}
-            )
+        Box(
+            modifier = Modifier
+                .background(PharmTheme.colors.background)
+                .padding(16.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                ConsultItemCard(
+                    item = ConsultItem(id = "1", userId = "u1", pharmacistId = "p1", nickName = "사용자", title = "일반 공개 상담입니다.", content = "...", isPublic = true, status = ConsultStatus.WAITING, createdAt = System.currentTimeMillis()),
+                    currentUserId = "u1",
+                    isPharmacist = false,
+                    onClick = {}
+                )
+
+                ConsultItemCard(
+                    item = ConsultItem(id = "2", userId = "u2", pharmacistId = "p1", nickName = "익명", title = "비밀글입니다", content = "...", isPublic = false, status = ConsultStatus.COMPLETED, createdAt = System.currentTimeMillis()),
+                    currentUserId = "u1", // 권한 없는 유저
+                    isPharmacist = false,
+                    onClick = {}
+                )
+            }
         }
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
@@ -1,28 +1,17 @@
 package com.moon.pharm.profile.medication.screen.component
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.component.item.PharmListItem
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
@@ -33,43 +22,31 @@ import com.moon.pharm.profile.medication.model.HistoryRecordUiModel
 @Composable
 fun HistoryRecordItem(
     uiModel: HistoryRecordUiModel,
-    onRecordClick: () -> Unit
+    onRecordClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val record = uiModel.record
     val borderColor = if (record.isTaken) PharmTheme.colors.success else PharmTheme.colors.warning
     val backgroundColor = if (record.isTaken) PharmTheme.colors.successContainer else PharmTheme.colors.warningContainer
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onRecordClick() }
-            .background(backgroundColor, RoundedCornerShape(10.dp))
-            .border(1.dp, borderColor, RoundedCornerShape(10.dp))
-            .padding(10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Column {
-            Text(
-                text = uiModel.medicationName,
-                fontWeight = FontWeight.Bold,
-                fontSize = 14.sp
-            )
-            Text(
-                text =
-                    if (record.isTaken) stringResource(R.string.medication_take_on)
-                    else stringResource(R.string.medication_take_off),
-                fontSize = 12.sp
+    PharmListItem(
+        modifier = modifier,
+        onClick = onRecordClick,
+        containerColor = backgroundColor,
+        borderColor = borderColor,
+        contentPadding = 10.dp,
+        headline = uiModel.medicationName,
+        subhead = if (record.isTaken) stringResource(R.string.medication_take_on)
+        else stringResource(R.string.medication_take_off),
+        trailing = {
+            Icon(
+                imageVector = if (record.isTaken) Icons.Default.CheckCircle else Icons.Default.Close,
+                contentDescription = null,
+                tint = borderColor,
+                modifier = Modifier.size(24.dp)
             )
         }
-
-        Icon(
-            imageVector = if (record.isTaken) Icons.Default.CheckCircle else Icons.Default.Close,
-            contentDescription = null,
-            tint = borderColor,
-            modifier = Modifier.size(24.dp)
-        )
-    }
+    )
 }
 
 @ThemePreviews

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
@@ -1,26 +1,12 @@
 package com.moon.pharm.profile.medication.screen.component
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.component.item.PharmListItem
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
-import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
 import com.moon.pharm.domain.model.medication.MealTiming
 import com.moon.pharm.domain.model.medication.MedicationType
@@ -30,52 +16,20 @@ import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
 @Composable
 fun MedicationItemCard(
     item: TodayMedicationUiModel,
-    onTakeClick: (TodayMedicationUiModel) -> Unit
+    onTakeClick: (TodayMedicationUiModel) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = PharmTheme.colors.surface,
-            contentColor = PharmTheme.colors.primary
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        shape = RoundedCornerShape(12.dp),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = item.name,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = PharmTheme.colors.onSurface
-                    )
-                    Text(
-                        text = " · ${item.type.label}",
-                        fontSize = 13.sp,
-                        color = PharmTheme.colors.secondFont
-                    )
-                }
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "${item.mealTiming.label} · ${item.repeatType.label}",
-                    fontSize = 13.sp,
-                    color = PharmTheme.colors.secondFont
-                )
-            }
-
+    PharmListItem(
+        modifier = modifier,
+        headline = "${item.name} · ${item.type.label}",
+        subhead = "${item.mealTiming.label} · ${item.repeatType.label}",
+        trailing = {
             MedicationCheckButton(
                 isTaken = item.isTaken,
                 onClick = { onTakeClick(item) }
             )
         }
-    }
+    )
 }
 
 @ThemePreviews


### PR DESCRIPTION
- `PharmListItem`에 동적 배경색(containerColor), 테두리(borderColor), 패딩 속성을 추가하여 재사용성 강화
- 중복되는 레이아웃 보일러플레이트 코드 대폭 제거 및 앱 전체 리스트 디자인 일관성 확보
- 적용 대상:
  - [component_ui] 공통 아이템: `PharmacyListItem`, `PharmacistListItem`
  - [consult] 상담 리스트: `ConsultItemCard`
  - [profile] 복약 관리 리스트: `HistoryRecordItem`, `MedicationItemCard`

Close #94