### PR TITLE
feat(consult): 상담글/답변 수정 및 삭제 기능 추가 및 UI/UX 개선

### DIFF
--- a/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
+++ b/data/src/main/java/com/moon/pharm/data/common/PharmConst.kt
@@ -32,6 +32,9 @@ const val FIELD_STATUS = "status"
 const val FIELD_ANSWER = "answer"
 const val FIELD_ANSWER_PHARMACIST_NAME = "answer.pharmacistName"
 const val FIELD_FCM_TOKEN = "fcmToken"
+const val FIELD_TITLE = "title"
+const val FIELD_CONTENT = "content"
+const val FIELD_PUBLIC = "public"
 
 // 에러 메시지 (Error Messages)
 const val ERROR_MSG_PHARMACY_NOT_FOUND = "Pharmacy not found"

--- a/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/ConsultDataSource.kt
@@ -9,8 +9,11 @@ interface ConsultDataSource {
     fun getConsultItems(): Flow<List<ConsultItemDTO>>
     fun getConsultDetail(id: String): Flow<ConsultItemDTO?>
     fun getMyConsults(userId: String): Flow<List<ConsultItemDTO>>
-    fun getMyAnsweredConsults(pharmacistId: String): Flow<List<ConsultItemDTO>>
+    suspend fun updateConsult(consultId: String, title: String, content: String, isPublic: Boolean)
+    suspend fun deleteConsult(consultId: String)
 
+    fun getMyAnsweredConsults(pharmacistId: String): Flow<List<ConsultItemDTO>>
     suspend fun updateConsultAnswer(consultId: String, answerDto: ConsultAnswerDTO): ConsultItemDTO
+    suspend fun deleteConsultAnswer(consultId: String)
     suspend fun updatePharmacistNicknameInAnswers(pharmacistId: String, newNickname: String)
 }

--- a/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/datasource/remote/firebase/FirestoreConsultDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.moon.pharm.data.datasource.remote.firebase
 
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.Query
@@ -8,9 +9,12 @@ import com.moon.pharm.data.common.CONSULT_COLLECTION
 import com.moon.pharm.data.common.ERROR_MSG_CONSULT_NOT_FOUND
 import com.moon.pharm.data.common.FIELD_ANSWER
 import com.moon.pharm.data.common.FIELD_ANSWER_PHARMACIST_NAME
+import com.moon.pharm.data.common.FIELD_CONTENT
 import com.moon.pharm.data.common.FIELD_CREATED_AT
 import com.moon.pharm.data.common.FIELD_PHARMACIST_ID
+import com.moon.pharm.data.common.FIELD_PUBLIC
 import com.moon.pharm.data.common.FIELD_STATUS
+import com.moon.pharm.data.common.FIELD_TITLE
 import com.moon.pharm.data.common.FIELD_USER_ID
 import com.moon.pharm.data.datasource.ConsultDataSource
 import com.moon.pharm.data.datasource.remote.dto.ConsultAnswerDTO
@@ -62,6 +66,20 @@ class FirestoreConsultDataSourceImpl @Inject constructor(
             .map { snapshot ->
                 snapshot.toObjects(ConsultItemDTO::class.java)
             }
+    override suspend fun updateConsult(consultId: String, title: String, content: String, isPublic: Boolean) {
+        collection.document(consultId).update(
+            mapOf(
+                FIELD_TITLE to title,
+                FIELD_CONTENT to content,
+                FIELD_PUBLIC to isPublic
+            )
+        ).await()
+    }
+
+    override suspend fun deleteConsult(consultId: String) {
+        collection.document(consultId).delete().await()
+    }
+
 
     override fun getMyAnsweredConsults(pharmacistId: String): Flow<List<ConsultItemDTO>> =
         collection
@@ -89,6 +107,15 @@ class FirestoreConsultDataSourceImpl @Inject constructor(
                 status = ConsultStatus.COMPLETED.name
             )
         }.await()
+    }
+
+    override suspend fun deleteConsultAnswer(consultId: String) {
+        collection.document(consultId).update(
+            mapOf(
+                FIELD_ANSWER to FieldValue.delete(),
+                FIELD_STATUS to ConsultStatus.WAITING.name
+            )
+        ).await()
     }
 
     override suspend fun updatePharmacistNicknameInAnswers(pharmacistId: String, newNickname: String) {

--- a/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
+++ b/data/src/main/java/com/moon/pharm/data/repository/ConsultRepositoryImpl.kt
@@ -92,6 +92,16 @@ class ConsultRepositoryImpl @Inject constructor(
             .asDataResourceResult()
     }
 
+    override fun updateConsult(
+        consultId: String, title: String, content: String, isPublic: Boolean
+    ): Flow<DataResourceResult<Unit>> = wrapOperation {
+        dataSource.updateConsult(consultId, title, content, isPublic)
+    }
+
+    override fun deleteConsult(consultId: String): Flow<DataResourceResult<Unit>> = wrapOperation {
+        dataSource.deleteConsult(consultId)
+    }
+
     override fun getMyAnsweredConsultList(userId: String): Flow<DataResourceResult<List<ConsultItem>>> {
         return dataSource.getMyAnsweredConsults(userId)
             .map { dtoList -> dtoList.map { it.toDomain() } }
@@ -105,6 +115,10 @@ class ConsultRepositoryImpl @Inject constructor(
         val answerDto = answer.toDto()
         val updatedDto = dataSource.updateConsultAnswer(consultId, answerDto)
         updatedDto.toDomain()
+    }
+
+    override fun deleteConsultAnswer(consultId: String): Flow<DataResourceResult<Unit>> = wrapOperation {
+        dataSource.deleteConsultAnswer(consultId)
     }
 
     override suspend fun uploadImage(uri: String, userId: String): String {

--- a/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/repository/ConsultRepository.kt
@@ -10,10 +10,14 @@ interface ConsultRepository {
     fun getConsultItems(): Flow<DataResourceResult<List<ConsultItem>>>
     fun getConsultDetail(id: String): Flow<DataResourceResult<ConsultItem>>
     fun getMyConsult(userId: String): Flow<DataResourceResult<List<ConsultItem>>>
+    fun updateConsult(consultId: String, title: String, content: String, isPublic: Boolean): Flow<DataResourceResult<Unit>>
+    fun deleteConsult(consultId: String): Flow<DataResourceResult<Unit>>
+
     fun getMyAnsweredConsultList(userId: String): Flow<DataResourceResult<List<ConsultItem>>>
     fun registerAnswer(consultId: String, answer: ConsultAnswer): Flow<DataResourceResult<ConsultItem>>
-    suspend fun uploadImage(uri: String, userId: String): String
+    fun deleteConsultAnswer(consultId: String): Flow<DataResourceResult<Unit>>
 
+    suspend fun uploadImage(uri: String, userId: String): String
     suspend fun sendAnswerNotification(targetUserToken: String, consultId: String): DataResourceResult<Unit>
     suspend fun sendNewConsultNotification(targetToken: String, consultId: String): DataResourceResult<Unit>
     suspend fun updatePharmacistNicknameInAnswers(userId: String, newNickname: String): DataResourceResult<Unit>

--- a/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultDetailUseCase.kt
+++ b/domain/src/main/java/com/moon/pharm/domain/usecase/consult/GetConsultDetailUseCase.kt
@@ -18,7 +18,8 @@ import javax.inject.Inject
 data class ConsultDetailResult(
     val consult: ConsultItem,
     val pharmacist: Pharmacist?,
-    val isMyConsultToAnswer: Boolean
+    val isMyConsultToAnswer: Boolean,
+    val currentUserId: String? = null
 )
 
 class GetConsultDetailUseCase @Inject constructor(
@@ -59,7 +60,7 @@ class GetConsultDetailUseCase @Inject constructor(
                     currentUserId == originConsult.pharmacistId &&
                     originConsult.status == ConsultStatus.WAITING
 
-            emit(DataResourceResult.Success(ConsultDetailResult(consult, pharmacist, canAnswer)))
+            emit(DataResourceResult.Success(ConsultDetailResult(consult, pharmacist, canAnswer, currentUserId)))
         } else if (consultResult is DataResourceResult.Failure) {
             emit(DataResourceResult.Failure(consultResult.exception))
         }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/PharmButtons.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/button/PharmButtons.kt
@@ -10,15 +10,23 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults.outlinedIconButtonColors
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
@@ -114,6 +122,40 @@ fun PharmOutlinedButton(
     }
 }
 
+/**
+ * 아이콘 버튼 (기본 36dp).
+ * (0.3초 내 중복 클릭 무시)
+ */
+@Composable
+fun PharmIconButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 24.dp,
+    buttonSize: Dp = 36.dp,
+    shape: Shape = RoundedCornerShape(10.dp),
+    color: Color = PharmTheme.colors.secondFont
+) {
+    val multipleEventsCutter = remember { MultipleEventsCutter.get() }
+
+    OutlinedIconButton(
+        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        modifier = modifier.size(buttonSize),
+        shape = shape,
+        border = BorderStroke(1.dp, color),
+        colors = outlinedIconButtonColors(
+            contentColor = color
+        )
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(iconSize)
+        )
+    }
+}
+
 @ThemePreviews
 @Composable
 private fun PharmButtonsPreview() {
@@ -129,6 +171,11 @@ private fun PharmButtonsPreview() {
             PharmOutlinedButton(onClick = {}) {
                 Text(text = "테두리 버튼")
             }
+            PharmIconButton(
+                icon = Icons.Default.Edit,
+                contentDescription = "수정",
+                onClick = {}
+            )
         }
     }
 }

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmConfirmDialog.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/component/dialog/PharmConfirmDialog.kt
@@ -1,0 +1,66 @@
+package com.moon.pharm.component_ui.component.dialog
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.R
+import com.moon.pharm.component_ui.theme.PharmMasterTheme
+import com.moon.pharm.component_ui.theme.PharmTheme
+import com.moon.pharm.component_ui.util.ThemePreviews
+
+/**
+ * '확인' 및 '취소' 두 가지 액션이 필요한 경우 사용하는 공통 다이얼로그
+ */
+@Composable
+fun PharmConfirmDialog(
+    title: String,
+    content: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    confirmText: String = stringResource(R.string.common_confirm),
+    cancelText: String = stringResource(R.string.common_cancel),
+    confirmTextColor: Color = PharmTheme.colors.primary
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(text = title, fontWeight = FontWeight.Bold, fontSize = 16.sp) },
+        text = { Text(text = content, fontSize = 14.sp, color = PharmTheme.colors.onSurface) },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm()
+                onDismiss()
+            }) {
+                Text(text = confirmText, color = confirmTextColor, fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = cancelText, color = PharmTheme.colors.primary)
+            }
+        },
+        containerColor = PharmTheme.colors.surface,
+        textContentColor = PharmTheme.colors.onSurface
+    )
+}
+
+@ThemePreviews
+@Composable
+private fun PharmConfirmDialogPreview() {
+    PharmMasterTheme {
+        PharmConfirmDialog(
+            title = "상담글 삭제",
+            content = "정말 삭제하시겠습니까?\n삭제된 글은 복구할 수 없습니다.",
+            confirmText = "삭제",
+            onConfirm = {},
+            onDismiss = {}
+        )
+    }
+}

--- a/features/component-ui/src/main/java/com/moon/pharm/component_ui/navigation/ContentNavRoute.kt
+++ b/features/component-ui/src/main/java/com/moon/pharm/component_ui/navigation/ContentNavRoute.kt
@@ -29,7 +29,7 @@ sealed interface ContentNavigationRoute : PharmNavigation {
     @Serializable
     data object ConsultGraph : ContentNavigationRoute
     @Serializable
-    data object ConsultWriteGraph : ContentNavigationRoute
+    data class ConsultWriteGraph(val consultId: String? = null) : ContentNavigationRoute
     @Serializable
     data object ConsultTab : ContentNavigationRoute
     @Serializable

--- a/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMessageMapper.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/mapper/ConsultUiMessageMapper.kt
@@ -12,6 +12,9 @@ fun ConsultUiMessage.asString(): String {
         ConsultUiMessage.TitleTooShort -> stringResource(R.string.consult_error_title_short)
         ConsultUiMessage.PharmacistRequired -> stringResource(R.string.consult_error_pharmacist_required)
         ConsultUiMessage.CreateFailed -> stringResource(R.string.consult_create_failed)
+        ConsultUiMessage.ConsultUpdateSuccess -> stringResource(R.string.consult_update_success)
+        ConsultUiMessage.ConsultDeleteSuccess -> stringResource(R.string.consult_delete_success)
         ConsultUiMessage.AnswerRegisterSuccess -> stringResource(R.string.consult_answer_success)
+        ConsultUiMessage.AnswerDeleteSuccess ->stringResource(R.string.consult_delete_success)
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/model/ConsultUiMessage.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/model/ConsultUiMessage.kt
@@ -7,5 +7,8 @@ sealed interface ConsultUiMessage : UiMessage {
     data object TitleTooShort : ConsultUiMessage
     data object PharmacistRequired : ConsultUiMessage
     data object CreateFailed : ConsultUiMessage
+    data object ConsultUpdateSuccess : ConsultUiMessage
+    data object ConsultDeleteSuccess : ConsultUiMessage
     data object AnswerRegisterSuccess : ConsultUiMessage
+    data object AnswerDeleteSuccess : ConsultUiMessage
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/navigation/ConsultNavGraphBuilder.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/navigation/ConsultNavGraphBuilder.kt
@@ -1,6 +1,7 @@
 package com.moon.pharm.consult.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -61,6 +62,15 @@ private inline fun <reified T : ContentNavigationRoute> NavGraphBuilder.consultW
             navController.getBackStackEntry<ContentNavigationRoute.ConsultWriteGraph>()
         }
         val sharedViewModel: ConsultWriteViewModel = hiltViewModel(parentEntry)
+
+        val routeParams = parentEntry.toRoute<ContentNavigationRoute.ConsultWriteGraph>()
+        val editConsultId = routeParams.consultId
+
+        LaunchedEffect(editConsultId) {
+            if (editConsultId != null) {
+                sharedViewModel.setEditMode(editConsultId)
+            }
+        }
         content(sharedViewModel)
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultConfirmScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultConfirmScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -34,11 +36,18 @@ fun ConsultConfirmScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
+    var currentSnackbarType by remember { mutableStateOf(SnackbarType.INFO) }
     val userMessage = uiState.userMessage
     val messageText = (userMessage as? ConsultUiMessage)?.asString()
 
     LaunchedEffect(userMessage) {
         if (userMessage != null && messageText != null) {
+            currentSnackbarType = when (userMessage) {
+                is ConsultUiMessage.AnswerRegisterSuccess,
+                is ConsultUiMessage.ConsultDeleteSuccess,
+                is ConsultUiMessage.AnswerDeleteSuccess -> SnackbarType.INFO
+                else -> SnackbarType.ERROR
+            }
             snackbarHostState.showSnackbar(messageText)
             viewModel.userMessageShown()
         }
@@ -77,7 +86,7 @@ fun ConsultConfirmScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { data ->
-                CustomSnackbar(snackbarData = data, type = SnackbarType.ERROR)
+                CustomSnackbar(snackbarData = data, type = currentSnackbarType)
             }
         }
     ) { innerPadding ->

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultDetailScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultDetailScreen.kt
@@ -8,16 +8,20 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.moon.pharm.component_ui.component.bar.PharmTopBar
+import com.moon.pharm.component_ui.component.dialog.PharmConfirmDialog
 import com.moon.pharm.component_ui.component.snackbar.CustomSnackbar
 import com.moon.pharm.component_ui.component.snackbar.SnackbarType
 import com.moon.pharm.component_ui.model.TopBarData
 import com.moon.pharm.component_ui.model.TopBarNavigationType
+import com.moon.pharm.component_ui.navigation.ContentNavigationRoute
 import com.moon.pharm.consult.R
 import com.moon.pharm.consult.mapper.asString
 import com.moon.pharm.consult.model.ConsultUiMessage
@@ -32,11 +36,15 @@ fun ConsultDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val answerContent by viewModel.answerContent.collectAsStateWithLifecycle()
-    val isPharmacistMode = uiState.canAnswer
+    val isPharmacistMode = uiState.canAnswer || uiState.isEditingAnswer
     val snackbarHostState = remember { SnackbarHostState() }
+    var currentSnackbarType by remember { mutableStateOf(SnackbarType.INFO) }
 
     val userMessage = uiState.userMessage
     val messageText = (userMessage as? ConsultUiMessage)?.asString()
+
+    var showDeleteConsultDialog by remember { mutableStateOf(false) }
+    var showDeleteAnswerDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(consultId) {
         if (consultId.isNotBlank()) {
@@ -46,8 +54,23 @@ fun ConsultDetailScreen(
 
     LaunchedEffect(userMessage) {
         if (userMessage != null && messageText != null) {
+            currentSnackbarType = when (userMessage) {
+                is ConsultUiMessage.AnswerRegisterSuccess,
+                is ConsultUiMessage.ConsultDeleteSuccess,
+                is ConsultUiMessage.AnswerDeleteSuccess -> SnackbarType.INFO
+                else -> SnackbarType.ERROR
+            }
+
             snackbarHostState.showSnackbar(messageText)
             viewModel.userMessageShown()
+
+            when (userMessage) {
+                is ConsultUiMessage.ConsultDeleteSuccess -> {
+                    navController.popBackStack()
+                }
+                is ConsultUiMessage.AnswerDeleteSuccess -> {}
+                else -> {}
+            }
         }
     }
 
@@ -63,7 +86,7 @@ fun ConsultDetailScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { data ->
-                CustomSnackbar(snackbarData = data, type = SnackbarType.ERROR)
+                CustomSnackbar(snackbarData = data, type = currentSnackbarType)
             }
         }
     ) { innerPadding ->
@@ -75,10 +98,44 @@ fun ConsultDetailScreen(
                 pharmacistImageUrl = uiState.answerPharmacistProfileUrl,
 
                 isPharmacistMode = isPharmacistMode,
+                isEditingAnswer = uiState.isEditingAnswer,
                 answerInput = answerContent,
                 onAnswerChange = viewModel::onAnswerContentChanged,
-                onSubmitAnswer = { viewModel.registerAnswer(consultId)}
+                onSubmitAnswer = { viewModel.registerAnswer(consultId)},
+
+                currentUserId = uiState.currentUserId,
+                onEditQuestion = {
+                    navController.navigate(ContentNavigationRoute.ConsultWriteGraph(consultId = consultId))
+                },
+                onDeleteQuestion = {
+                    showDeleteConsultDialog = true
+                },
+                onEditAnswer = {
+                    viewModel.startEditingAnswer()
+                },
+                onDeleteAnswer = {
+                    showDeleteAnswerDialog = true
+                }
             )
+            if (showDeleteConsultDialog) {
+                PharmConfirmDialog(
+                    title = stringResource(R.string.consult_delete_title),
+                    content = stringResource(R.string.consult_delete_content),
+                    confirmText = stringResource(R.string.consult_delete_confirm),
+                    onConfirm = { viewModel.deleteConsult(consultId) },
+                    onDismiss = { showDeleteConsultDialog = false }
+                )
+            }
+
+            if (showDeleteAnswerDialog) {
+                PharmConfirmDialog(
+                    title = stringResource(R.string.answer_delete_title),
+                    content = stringResource(R.string.answer_delete_content),
+                    confirmText = stringResource(R.string.consult_delete_confirm),
+                    onConfirm = { viewModel.deleteAnswer(consultId) },
+                    onDismiss = { showDeleteAnswerDialog = false }
+                )
+            }
         }
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultWriteScreen.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/ConsultWriteScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -36,11 +38,18 @@ fun ConsultWriteScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
+    var currentSnackbarType by remember { mutableStateOf(SnackbarType.INFO) }
     val userMessage = uiState.userMessage
     val messageText = (userMessage as? ConsultUiMessage)?.asString()
 
     LaunchedEffect(userMessage) {
         if (userMessage != null && messageText != null) {
+            currentSnackbarType = when (userMessage) {
+                is ConsultUiMessage.AnswerRegisterSuccess,
+                is ConsultUiMessage.ConsultDeleteSuccess,
+                is ConsultUiMessage.AnswerDeleteSuccess -> SnackbarType.INFO
+                else -> SnackbarType.ERROR
+            }
             snackbarHostState.showSnackbar(messageText)
             viewModel.userMessageShown()
         }
@@ -51,6 +60,9 @@ fun ConsultWriteScreen(
             when (event) {
                 is ConsultWriteViewModel.WriteEvent.MoveToPharmacist -> {
                     navController.navigate(ContentNavigationRoute.ConsultTabPharmacistScreen)
+                }
+                is ConsultWriteViewModel.WriteEvent.UpdateSuccess -> {
+                    navController.navigateUp()
                 }
             }
         }
@@ -78,7 +90,7 @@ fun ConsultWriteScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { data ->
-                CustomSnackbar(snackbarData = data, type = SnackbarType.ERROR)
+                CustomSnackbar(snackbarData = data, type = currentSnackbarType)
             }
         }
     ) { innerPadding ->
@@ -89,6 +101,7 @@ fun ConsultWriteScreen(
                 images = uiState.images,
                 isPublic = uiState.isPublic,
                 isButtonEnabled = isFormValid,
+                isEditMode = uiState.isEditMode,
                 onTitleChange = viewModel::onTitleChanged,
                 onContentChange = viewModel::onContentChanged,
                 onImageRemove = { removedUrl ->

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultDetailContent.kt
@@ -34,9 +34,16 @@ fun ConsultDetailContent(
     pharmacistImageUrl: String?,
 
     isPharmacistMode: Boolean = false,
+    isEditingAnswer: Boolean = false,
     answerInput: String = "",
     onAnswerChange: (String) -> Unit = {},
-    onSubmitAnswer: () -> Unit = {}
+    onSubmitAnswer: () -> Unit = {},
+
+    currentUserId: String?,
+    onEditQuestion: () -> Unit = {},
+    onDeleteQuestion: () -> Unit = {},
+    onEditAnswer: () -> Unit = {},
+    onDeleteAnswer: () -> Unit = {}
 ) {
     Box(
         modifier = Modifier
@@ -51,21 +58,39 @@ fun ConsultDetailContent(
                     .padding(horizontal = 24.dp, vertical = 20.dp)
             ) {
                 item {
-                    QuestionSection(item)
+                    QuestionSection(
+                        item = item,
+                        currentUserId = currentUserId,
+                        onEditClick = onEditQuestion,
+                        onDeleteClick = onDeleteQuestion)
                     Spacer(modifier = Modifier.height(24.dp))
                 }
                 item {
                     if (item.status == ConsultStatus.COMPLETED && item.answer != null) {
-                        AnswerSection(
-                            pharmacist = pharmacist,
-                            pharmacistImageUrl = pharmacistImageUrl,
-                            item = item
-                        )
+                        if (isEditingAnswer) {
+                            Spacer(modifier = Modifier.height(20.dp))
+                            PharmacistAnswerInputSection(
+                                input = answerInput,
+                                isEditMode = true,
+                                onValueChange = onAnswerChange,
+                                onSubmit = onSubmitAnswer
+                            )
+                        } else {
+                            AnswerSection(
+                                pharmacist = pharmacist,
+                                pharmacistImageUrl = pharmacistImageUrl,
+                                item = item,
+                                currentUserId = currentUserId,
+                                onEditClick = onEditAnswer,
+                                onDeleteClick = onDeleteAnswer
+                            )
+                        }
                     } else if (item.status == ConsultStatus.WAITING) {
                         Spacer(modifier = Modifier.height(20.dp))
                         if (isPharmacistMode) {
                             PharmacistAnswerInputSection(
                                 input = answerInput,
+                                isEditMode = false,
                                 onValueChange = onAnswerChange,
                                 onSubmit = onSubmitAnswer
                             )
@@ -101,9 +126,25 @@ private fun ConsultDetailContentPreview() {
     PharmMasterTheme {
         ConsultDetailContent(
             isLoading = false,
-            item = ConsultItem(id = "1", userId = "u1", pharmacistId = "p1", nickName = "질문자", title = "두통약 문의", content = "어떻게 먹나요?", isPublic = true, status = ConsultStatus.WAITING, createdAt = System.currentTimeMillis()),
+            item = ConsultItem(
+                id = "1",
+                userId = "u1",
+                pharmacistId = "p1",
+                nickName = "질문자",
+                title = "두통약 문의",
+                content = "어떻게 먹나요?",
+                isPublic = true,
+                status = ConsultStatus.WAITING,
+                createdAt = System.currentTimeMillis()
+            ),
             pharmacist = null,
-            pharmacistImageUrl = null
+            pharmacistImageUrl = null,
+
+            currentUserId = "u1",
+            onEditQuestion = {},
+            onDeleteQuestion = {},
+            onEditAnswer = {},
+            onDeleteAnswer = {}
         )
     }
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteBottomBar.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteBottomBar.kt
@@ -19,6 +19,7 @@ import com.moon.pharm.consult.R
 fun ConsultWriteBottomBar(
     isPublic: Boolean,
     isButtonEnabled: Boolean,
+    isEditMode: Boolean,
     onVisibilityChange: (Boolean) -> Unit,
     onNextClick: () -> Unit
 ) {
@@ -31,7 +32,7 @@ fun ConsultWriteBottomBar(
         Spacer(modifier = Modifier.height(10.dp))
 
         PharmPrimaryButton(
-            text = stringResource(R.string.consult_button_next),
+            text = if (isEditMode) stringResource(R.string.consult_button_edit) else stringResource(R.string.consult_button_next),
             onClick = onNextClick,
             enabled = isButtonEnabled
         )
@@ -46,6 +47,7 @@ private fun ConsultWriteBottomBarPreview() {
             ConsultWriteBottomBar(
                 isPublic = true,
                 isButtonEnabled = true,
+                isEditMode = true,
                 onVisibilityChange = {},
                 onNextClick = {}
             )

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteContent.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteContent.kt
@@ -22,6 +22,7 @@ fun ConsultWriteContent(
     images: List<String>,
     isPublic: Boolean,
     isButtonEnabled: Boolean,
+    isEditMode: Boolean,
     onTitleChange: (String) -> Unit,
     onContentChange: (String) -> Unit,
     onImageRemove: (String) -> Unit,
@@ -55,6 +56,7 @@ fun ConsultWriteContent(
         ConsultWriteBottomBar(
             isPublic = isPublic,
             isButtonEnabled = isButtonEnabled,
+            isEditMode = isEditMode,
             onVisibilityChange = onVisibilityChange,
             onNextClick = onNextClick
         )

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/component/ConsultWriteForm.kt
@@ -92,6 +92,7 @@ private fun ConsultWriteContentPreview() {
             images = emptyList(),
             isPublic = true,
             isButtonEnabled = false,
+            isEditMode = true,
             onTitleChange = {},
             onContentChange = {},
             onImageRemove = {},

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/AnswerSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/AnswerSection.kt
@@ -1,17 +1,26 @@
 package com.moon.pharm.consult.screen.section
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.component.button.PharmIconButton
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
 import com.moon.pharm.consult.R
@@ -26,7 +35,10 @@ import com.moon.pharm.domain.model.consult.ConsultItem
 fun AnswerSection(
     pharmacist: Pharmacist?,
     pharmacistImageUrl: String?,
-    item: ConsultItem
+    item: ConsultItem,
+    currentUserId: String? = null,
+    onEditClick: () -> Unit = {},
+    onDeleteClick: () -> Unit = {}
 ) {
     val answer = item.answer ?: return
 
@@ -48,6 +60,27 @@ fun AnswerSection(
         AnswerContentCard(
             answer = answer
         )
+
+        if (currentUserId == answer.pharmacistId) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                PharmIconButton(
+                    icon = Icons.Default.Edit,
+                    contentDescription = stringResource(R.string.consult_confirm_edit_btn),
+                    onClick = onEditClick
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                PharmIconButton(
+                    icon = Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.consult_delete_confirm),
+                    onClick = onDeleteClick
+                )
+            }
+        }
     }
 }
 
@@ -69,7 +102,10 @@ private fun AnswerSectionPreview() {
             AnswerSection(
                 pharmacist = Pharmacist(userId = "p1", name = "김약사", bio = "상담 가능", placeId = "1", pharmacyName = "달빛약국"),
                 pharmacistImageUrl = null,
-                item = dummyItemWithAnswer
+                item = dummyItemWithAnswer,
+                currentUserId = "p1",
+                onEditClick = {},
+                onDeleteClick = {}
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/PharmacistAnswerInputSection.kt
@@ -27,6 +27,7 @@ import com.moon.pharm.consult.R
 @Composable
 fun PharmacistAnswerInputSection(
     input: String,
+    isEditMode: Boolean = false,
     onValueChange: (String) -> Unit,
     onSubmit: () -> Unit
 ) {
@@ -37,7 +38,7 @@ fun PharmacistAnswerInputSection(
             .padding(16.dp)
     ) {
         Text(
-            text = "약사님, 답변을 등록해주세요",
+            text = "약사님, 답변을 작성해주세요",
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             color = PharmTheme.colors.primary
@@ -63,7 +64,7 @@ fun PharmacistAnswerInputSection(
         Spacer(modifier = Modifier.height(16.dp))
 
         PharmPrimaryButton(
-            text = "답변 등록하기",
+            text = if (isEditMode) stringResource(R.string.consult_answer_edit_button) else stringResource(R.string.consult_answer_register_button),
             onClick = onSubmit,
             modifier = Modifier.fillMaxWidth(),
             enabled = input.isNotBlank()

--- a/features/consult/src/main/java/com/moon/pharm/consult/screen/section/QuestionSection.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/screen/section/QuestionSection.kt
@@ -8,28 +8,40 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moon.pharm.component_ui.component.StatusBadge
+import com.moon.pharm.component_ui.component.button.PharmIconButton
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
 import com.moon.pharm.component_ui.util.toDisplayDateTimeString
+import com.moon.pharm.consult.R
 import com.moon.pharm.consult.screen.component.ConsultImageItem
 import com.moon.pharm.consult.screen.component.ConsultPreviewData
 import com.moon.pharm.domain.model.consult.ConsultItem
 import com.moon.pharm.domain.model.consult.ConsultStatus
 
 @Composable
-fun QuestionSection(item: ConsultItem) {
+fun QuestionSection(
+    item: ConsultItem,
+    currentUserId: String?,
+    onEditClick: () -> Unit = {},
+    onDeleteClick: () -> Unit = {}
+) {
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -81,16 +93,41 @@ fun QuestionSection(item: ConsultItem) {
                 }
             }
         }
+        if (currentUserId == item.userId) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                PharmIconButton(
+                    icon = Icons.Default.Edit,
+                    contentDescription = stringResource(R.string.consult_confirm_edit_btn),
+                    onClick = onEditClick
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                PharmIconButton(
+                    icon = Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.consult_delete_confirm),
+                    onClick = onDeleteClick
+                )
+            }
+        }
     }
 }
 
 @ThemePreviews
 @Composable
 private fun QuestionSectionPreview() {
+    val dummyItem = ConsultPreviewData.dummyConsultItems.first()
+
     PharmMasterTheme {
         Box(modifier = Modifier.padding(16.dp)) {
             QuestionSection(
-                item = ConsultPreviewData.dummyConsultItems.first()
+                item = dummyItem,
+                currentUserId = dummyItem.userId,
+                onEditClick = {},
+                onDeleteClick = {}
             )
         }
     }

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultDetailUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultDetailUiState.kt
@@ -11,5 +11,7 @@ data class ConsultDetailUiState(
     val selectedItem: ConsultItem? = null,
     val answerPharmacist: Pharmacist? = null,
     val answerPharmacistProfileUrl: String? = null,
-    val canAnswer: Boolean = false
+    val canAnswer: Boolean = false,
+    val currentUserId: String? = null,
+    val isEditingAnswer: Boolean = false
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultDetailViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultDetailViewModel.kt
@@ -39,7 +39,8 @@ class ConsultDetailViewModel @Inject constructor(
                             isLoading = false,
                             selectedItem = result.resultData.consult,
                             answerPharmacist = result.resultData.pharmacist,
-                            canAnswer = result.resultData.isMyConsultToAnswer
+                            canAnswer = result.resultData.isMyConsultToAnswer,
+                            currentUserId = result.resultData.currentUserId
                         )
                         is DataResourceResult.Failure -> state.copy(
                             isLoading = false,
@@ -53,6 +54,12 @@ class ConsultDetailViewModel @Inject constructor(
 
     fun onAnswerContentChanged(content: String) {
         _answerContent.value = content
+    }
+
+    fun startEditingAnswer() {
+        val currentAnswer = _uiState.value.selectedItem?.answer?.content ?: ""
+        _answerContent.value = currentAnswer
+        _uiState.update { it.copy(isEditingAnswer = true) }
     }
 
     fun registerAnswer(consultId: String) {
@@ -78,6 +85,7 @@ class ConsultDetailViewModel @Inject constructor(
                                 isLoading = false,
                                 selectedItem = result.resultData,
                                 canAnswer = false,
+                                isEditingAnswer = false,
                                 userMessage = ConsultUiMessage.AnswerRegisterSuccess
                             )
                         }
@@ -87,6 +95,42 @@ class ConsultDetailViewModel @Inject constructor(
                     is DataResourceResult.Failure -> {
                         _uiState.update { it.copy(isLoading = false, userMessage = ConsultUiMessage.CreateFailed) }
                     }
+                }
+            }
+        }
+    }
+
+
+    fun deleteConsult(consultId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            consultRepository.deleteConsult(consultId).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Success -> {
+                        _uiState.update { it.copy(isLoading = false, userMessage = ConsultUiMessage.ConsultDeleteSuccess) }
+                    }
+                    is DataResourceResult.Failure -> {
+                        _uiState.update { it.copy(isLoading = false, userMessage = ConsultUiMessage.CreateFailed) }
+                    }
+                    is DataResourceResult.Loading -> { /* 로딩 처리 */ }
+                }
+            }
+        }
+    }
+
+    fun deleteAnswer(consultId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            consultRepository.deleteConsultAnswer(consultId).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Success -> {
+                        _uiState.update { it.copy(isLoading = false, canAnswer = true, userMessage = ConsultUiMessage.ConsultDeleteSuccess) }
+                        getConsultDetail(consultId)
+                    }
+                    is DataResourceResult.Failure -> {
+                        _uiState.update { it.copy(isLoading = false) }
+                    }
+                    is DataResourceResult.Loading -> { }
                 }
             }
         }
@@ -108,4 +152,5 @@ class ConsultDetailViewModel @Inject constructor(
     fun userMessageShown() {
         _uiState.update { it.copy(userMessage = null) }
     }
+
 }

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultWriteUiState.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultWriteUiState.kt
@@ -18,5 +18,7 @@ data class ConsultWriteUiState(
     val searchResults: List<Pharmacy> = emptyList(),
     val selectedPharmacy: Pharmacy? = null,
     val availablePharmacists: List<Pharmacist> = emptyList(),
-    val selectedPharmacistId: String? = null
+    val selectedPharmacistId: String? = null,
+
+    val isEditMode: Boolean = false
 )

--- a/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultWriteViewModel.kt
+++ b/features/consult/src/main/java/com/moon/pharm/consult/viewmodel/ConsultWriteViewModel.kt
@@ -44,6 +44,7 @@ class ConsultWriteViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
+    private var editingConsultId: String? = null
     private val _searchQuery = MutableStateFlow("")
 
     private val _uiState = MutableStateFlow(ConsultWriteUiState())
@@ -57,6 +58,7 @@ class ConsultWriteViewModel @Inject constructor(
 
     sealed interface WriteEvent {
         data object MoveToPharmacist : WriteEvent
+        data object UpdateSuccess : WriteEvent
     }
 
     init {
@@ -66,6 +68,36 @@ class ConsultWriteViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .filter { it.isNotBlank() }
                 .collectLatest { query -> searchPharmacies(query) }
+        }
+    }
+
+    fun setEditMode(consultId: String) {
+        if (editingConsultId == consultId) return
+        editingConsultId = consultId
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            consultRepository.getConsultDetail(consultId).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Loading -> _uiState.update { it.copy(isLoading = true) }
+                    is DataResourceResult.Success -> {
+                        val consult = result.resultData
+                        _uiState.update { state ->
+                            state.copy(
+                                isLoading = false,
+                                isEditMode = true,
+                                title = consult.title,
+                                content = consult.content,
+                                isPublic = consult.isPublic,
+                                images = consult.images.map { it.imageUrl }
+                            )
+                        }
+                    }
+                    is DataResourceResult.Failure -> {
+                        _uiState.update { it.copy(isLoading = false, userMessage = UiMessage.LoadDataFailed) }
+                    }
+                }
+            }
         }
     }
 
@@ -175,8 +207,12 @@ class ConsultWriteViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
-            _writeEvent.emit(WriteEvent.MoveToPharmacist)
+        if (state.isEditMode) {
+            submitConsult()
+        } else {
+            viewModelScope.launch {
+                _writeEvent.emit(WriteEvent.MoveToPharmacist)
+            }
         }
     }
 
@@ -186,6 +222,34 @@ class ConsultWriteViewModel @Inject constructor(
 
     fun submitConsult() {
         val state = _uiState.value
+
+        // Update
+        val editId = editingConsultId
+        if (editId != null) {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                consultRepository.updateConsult(
+                    consultId = editId,
+                    title = state.title,
+                    content = state.content,
+                    isPublic = state.isPublic
+                ).collectLatest { result ->
+                    when (result) {
+                        is DataResourceResult.Loading -> _uiState.update { it.copy(isLoading = true) }
+                        is DataResourceResult.Success -> {
+                            _uiState.update { it.copy(isLoading = false, isConsultCreated = true) }
+                            _writeEvent.emit(WriteEvent.UpdateSuccess)
+                        }
+                        is DataResourceResult.Failure -> {
+                            _uiState.update { it.copy(isLoading = false, userMessage = ConsultUiMessage.CreateFailed) }
+                        }
+                    }
+                }
+            }
+            return
+        }
+
+        // Create
         val userId = validateAndGetUserId(state) ?: return
 
         viewModelScope.launch {

--- a/features/consult/src/main/res/values/strings.xml
+++ b/features/consult/src/main/res/values/strings.xml
@@ -33,6 +33,15 @@
     <string name="consult_secret_icon_desc">비공개</string>
     <string name="consult_secret_hidden_title">비공개 상담입니다.</string>
 
+    <string name="consult_update_success">수정이 완료되었습니다.</string>
+
+    <string name="consult_delete_title">상담글 삭제</string>
+    <string name="consult_delete_content">정말 삭제하시겠습니까?\n삭제된 글은 복구할 수 없습니다.</string>
+    <string name="consult_delete_confirm">삭제</string>
+
+    <string name="consult_delete_success">삭제되었습니다.</string>
+    <string name="consult_delete_failed">삭제에 실패했습니다. 다시 시도해주세요.</string>
+
     <!--  WriteScreen  -->
     <string name="consult_write_placeholder_title">제목을 입력해주세요</string>
     <string name="consult_write_placeholder_content">구체적인 증상, 복용 중인 다른 약물 정보 등을 자세히 작성해주세요.</string>
@@ -45,6 +54,7 @@
     <string name="consult_photo_delete_desc">삭제</string>
 
     <string name="consult_button_next">다음</string>
+    <string name="consult_button_edit">수정하기</string>
 
     <!--  PharmacistScreen  -->
     <string name="consult_search_select_pharmacist">약사 선택</string>
@@ -79,4 +89,11 @@
     <!--  Answer  -->
     <string name="consult_answer_success">답변이 등록되었습니다.</string>
     <string name="consult_answer_write_placeholder_content">답변을 작성해주세요.</string>
+
+    <string name="consult_answer_input_title">약사님, 답변을 작성해주세요</string>
+    <string name="consult_answer_edit_button">답변 수정하기</string>
+    <string name="consult_answer_register_button">답변 등록하기</string>
+
+    <string name="answer_delete_title">답변 삭제</string>
+    <string name="answer_delete_content">등록한 답변을 삭제하시겠습니까?</string>
 </resources>


### PR DESCRIPTION
[UI]
- 작성 화면(ConsultWriteScreen) 및 답변 입력창에 수정 모드(isEditMode) UI 분기 처리
- 스낵바 타입을 결과(성공/에러)에 따라 동적으로 변하도록 개선
- 공통 확인 다이얼로그(PharmConfirmDialog) 추가 및 삭제 재확인 로직 적용

[Feature]
- 게시글/답변 수정 시, 상세 화면으로 복귀하도록 흐름 개선
- 게시글 삭제와 답변 삭제 상태 분리 및 개별 분기 처리
- 약사 답변 수정 기능 추가 (isEditingAnswer)
- Compose Type-Safe Navigation 적용하여 수정 화면으로 consultId 안전하게 전달

Close #8