### PR TITLE
feat(medication): 복약 삭제 기능 추가 및 전체 스케줄 일괄 삭제 적용

### DIFF
--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHistoryScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHistoryScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -28,6 +29,7 @@ import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
 import com.moon.pharm.component_ui.util.toDisplayString
 import com.moon.pharm.component_ui.util.toQueryString
+import com.moon.pharm.profile.R
 import com.moon.pharm.profile.medication.screen.component.HistoryRecordItem
 import com.moon.pharm.profile.medication.screen.section.HistoryCalendarSection
 import com.moon.pharm.profile.medication.viewmodel.MedicationHistoryUiState
@@ -53,6 +55,9 @@ fun MedicationHistoryScreen(
         onDateClick = { viewModel.onDateSelected(it) },
         onToggleRecord = { medId, schId, isTaken ->
             viewModel.toggleRecord(medId, schId, isTaken, uiState.selectedDate)
+        },
+        onDeleteClick = { medicationId ->
+            viewModel.deleteMedication(medicationId)
         }
     )
 }
@@ -63,13 +68,14 @@ fun MedicationHistoryContent(
     onBackClick: () -> Unit,
     onMonthChanged: (YearMonth) -> Unit,
     onDateClick: (LocalDate) -> Unit,
-    onToggleRecord: (String, String, Boolean) -> Unit
+    onToggleRecord: (String, String, Boolean) -> Unit,
+    onDeleteClick: (String) -> Unit
 ) {
     Scaffold(
         topBar = {
             PharmTopBar(
                 data = TopBarData(
-                    title = "나의 복약 기록",
+                    title = stringResource(R.string.medication_history_title),
                     navigationType = TopBarNavigationType.Back,
                     onNavigationClick = onBackClick
                 )
@@ -92,7 +98,7 @@ fun MedicationHistoryContent(
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
-                text = "${uiState.selectedDate.toDisplayString()} 복약 상세",
+                text = stringResource(R.string.medication_history_detail_title, uiState.selectedDate.toDisplayString()),
                 modifier = Modifier.padding(horizontal = 20.dp),
                 fontWeight = FontWeight.Bold,
                 fontSize = 18.sp,
@@ -111,7 +117,7 @@ fun MedicationHistoryContent(
                 if (dailyRecords.isEmpty()) {
                     item {
                         Text(
-                            text = "복약 기록이 없습니다.",
+                            text = stringResource(R.string.medication_history_empty),
                             modifier = Modifier.padding(top = 20.dp),
                             color = PharmTheme.colors.secondFont
                         )
@@ -127,7 +133,8 @@ fun MedicationHistoryContent(
                                 uiModel.record.scheduleId,
                                 !uiModel.record.isTaken
                             )
-                        }
+                        },
+                        onDeleteClick = { onDeleteClick(uiModel.record.medicationId) }
                     )
                 }
             }
@@ -148,7 +155,8 @@ private fun MedicationHistoryContentPreview() {
             onBackClick = {},
             onMonthChanged = {},
             onDateClick = {},
-            onToggleRecord = { _, _, _ -> }
+            onToggleRecord = { _, _, _ -> },
+            onDeleteClick = {}
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHomeScreen.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/MedicationHomeScreen.kt
@@ -79,6 +79,9 @@ fun MedicationScreen(
                             scheduleId = item.scheduleId
                         )
                     )
+                },
+                onDeleteClick = { medicationId ->
+                    viewModel.onEvent(MedicationUiEvent.DeleteMedication(medicationId))
                 }
             )
         }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/HistoryRecordItem.kt
@@ -1,16 +1,29 @@
 package com.moon.pharm.profile.medication.screen.component
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.moon.pharm.component_ui.component.dialog.PharmConfirmDialog
 import com.moon.pharm.component_ui.component.item.PharmListItem
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
@@ -23,11 +36,15 @@ import com.moon.pharm.profile.medication.model.HistoryRecordUiModel
 fun HistoryRecordItem(
     uiModel: HistoryRecordUiModel,
     onRecordClick: () -> Unit,
+    onDeleteClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val record = uiModel.record
     val borderColor = if (record.isTaken) PharmTheme.colors.success else PharmTheme.colors.warning
     val backgroundColor = if (record.isTaken) PharmTheme.colors.successContainer else PharmTheme.colors.warningContainer
+
+    var showMenu by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     PharmListItem(
         modifier = modifier,
@@ -39,14 +56,48 @@ fun HistoryRecordItem(
         subhead = if (record.isTaken) stringResource(R.string.medication_take_on)
         else stringResource(R.string.medication_take_off),
         trailing = {
-            Icon(
-                imageVector = if (record.isTaken) Icons.Default.CheckCircle else Icons.Default.Close,
-                contentDescription = null,
-                tint = borderColor,
-                modifier = Modifier.size(24.dp)
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = if (record.isTaken) Icons.Default.CheckCircle else Icons.Default.Close,
+                    contentDescription = null,
+                    tint = borderColor,
+                    modifier = Modifier.size(24.dp)
+                )
+
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = stringResource(R.string.medication_option_menu_desc),
+                            tint = PharmTheme.colors.secondFont
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.medication_delete), color = MaterialTheme.colorScheme.error) },
+                            onClick = {
+                                showMenu = false
+                                showDeleteDialog = true
+                            }
+                        )
+                    }
+                }
+            }
         }
     )
+    if (showDeleteDialog) {
+        PharmConfirmDialog(
+            title = stringResource(R.string.medication_delete_dialog_title),
+            content = stringResource(R.string.medication_delete_dialog_content),
+            confirmText = stringResource(R.string.medication_delete_desc),
+            confirmTextColor = MaterialTheme.colorScheme.error,
+            onConfirm = { onDeleteClick(uiModel.record.medicationId) },
+            onDismiss = { showDeleteDialog = false }
+        )
+    }
 }
 
 @ThemePreviews
@@ -67,7 +118,8 @@ private fun HistoryRecordItemPreview() {
                         isTaken = true
                     )
                 ),
-                onRecordClick = {}
+                onRecordClick = {},
+                onDeleteClick = {}
             )
         }
     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationGroupItem.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationGroupItem.kt
@@ -31,7 +31,8 @@ import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
 @Composable
 fun MedicationGroupItem(
     group: MedicationTimeGroup,
-    onTakeClick: (TodayMedicationUiModel) -> Unit
+    onTakeClick: (TodayMedicationUiModel) -> Unit,
+    onDeleteClick: (String) -> Unit
 ) {
     val displayTime = group.time?.toLongOrNull()?.toDisplayTimeString() ?: group.time
 
@@ -59,7 +60,7 @@ fun MedicationGroupItem(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             group.items.forEach { item ->
-                MedicationItemCard(item = item, onTakeClick = onTakeClick)
+                MedicationItemCard(item = item, onTakeClick = onTakeClick, onDeleteClick = onDeleteClick)
             }
         }
     }
@@ -87,7 +88,8 @@ private fun MedicationGroupItemPreview() {
                         ),
                     )
                 ),
-                onTakeClick = {}
+                onTakeClick = {},
+                onDeleteClick = {}
             )
         }
     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationHomeContent.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationHomeContent.kt
@@ -27,7 +27,8 @@ fun MedicationHomeContent(
     totalCount: Int,
     completedCount: Int,
     onTabSelected: (MedicationPrimaryTab) -> Unit,
-    onTakeClick: (TodayMedicationUiModel) -> Unit
+    onTakeClick: (TodayMedicationUiModel) -> Unit,
+    onDeleteClick: (String) -> Unit
 ) {
     val tabTitles = MedicationPrimaryTab.entries.map { it.title }
 
@@ -52,7 +53,7 @@ fun MedicationHomeContent(
             }
 
             items(items = currentList, key = { it.time ?: "no-time" }) { group ->
-                MedicationGroupItem(group = group, onTakeClick = onTakeClick)
+                MedicationGroupItem(group = group, onTakeClick = onTakeClick, onDeleteClick = onDeleteClick)
             }
 
             item { Spacer(modifier = Modifier.height(50.dp)) }
@@ -70,7 +71,8 @@ private fun MedicationHomeContentPreview() {
             totalCount = 3,
             completedCount = 1,
             onTabSelected = {},
-            onTakeClick = {}
+            onTakeClick = {},
+            onDeleteClick = {}
         )
     }
 }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/component/MedicationItemCard.kt
@@ -9,15 +9,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.moon.pharm.component_ui.component.dialog.PharmConfirmDialog
 import com.moon.pharm.component_ui.theme.PharmMasterTheme
 import com.moon.pharm.component_ui.theme.PharmTheme
 import com.moon.pharm.component_ui.util.ThemePreviews
@@ -25,12 +38,18 @@ import com.moon.pharm.domain.model.medication.MealTiming
 import com.moon.pharm.domain.model.medication.MedicationType
 import com.moon.pharm.domain.model.medication.RepeatType
 import com.moon.pharm.domain.model.medication.TodayMedicationUiModel
+import com.moon.pharm.profile.R
 
 @Composable
 fun MedicationItemCard(
     item: TodayMedicationUiModel,
-    onTakeClick: (TodayMedicationUiModel) -> Unit
+    onTakeClick: (TodayMedicationUiModel) -> Unit,
+    onDeleteClick: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
     Card(
         colors = CardDefaults.cardColors(
             containerColor = PharmTheme.colors.surface,
@@ -38,7 +57,7 @@ fun MedicationItemCard(
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = RoundedCornerShape(12.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     ) {
         Row(
             modifier = Modifier
@@ -68,11 +87,55 @@ fun MedicationItemCard(
                     color = PharmTheme.colors.secondFont
                 )
             }
-            MedicationCheckButton(
-                isTaken = item.isTaken,
-                onClick = { onTakeClick(item) }
-            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                MedicationCheckButton(
+                    isTaken = item.isTaken,
+                    onClick = { onTakeClick(item) }
+                )
+
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = stringResource(R.string.medication_option_menu_desc),
+                            tint = PharmTheme.colors.secondFont
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(R.string.medication_delete),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            onClick = {
+                                showMenu = false
+                                showDeleteDialog = true
+                            }
+                        )
+                    }
+                }
+            }
         }
+    }
+    if (showDeleteDialog) {
+        PharmConfirmDialog(
+            title = stringResource(R.string.medication_delete_dialog_title),
+            content = stringResource(R.string.medication_delete_dialog_content),
+            confirmText = stringResource(R.string.medication_delete_desc),
+            confirmTextColor = MaterialTheme.colorScheme.error,
+            onConfirm = {
+                onDeleteClick(item.medicationId)
+            },
+            onDismiss = {
+                showDeleteDialog = false
+            }
+        )
     }
 }
 
@@ -93,7 +156,8 @@ private fun MedicationItemCardPreview() {
                     mealTiming = MealTiming.AFTER_MEAL,
                     isTaken = false
                 ),
-                onTakeClick = {}
+                onTakeClick = {},
+                onDeleteClick = {}
             )
         }
     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationInfoSection.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/screen/section/MedicationInfoSection.kt
@@ -81,7 +81,7 @@ fun MedicationInfoSection(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Close,
-                            contentDescription = "삭제",
+                            contentDescription = stringResource(R.string.medication_delete_desc),
                             tint = PharmTheme.colors.placeholder
                         )
                     }

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationHistoryViewModel.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationHistoryViewModel.kt
@@ -6,6 +6,7 @@ import com.moon.pharm.component_ui.util.toQueryString
 import com.moon.pharm.domain.model.medication.IntakeRecord
 import com.moon.pharm.domain.model.medication.Medication
 import com.moon.pharm.domain.repository.AuthRepository
+import com.moon.pharm.domain.repository.MedicationRepository
 import com.moon.pharm.domain.result.DataResourceResult
 import com.moon.pharm.domain.usecase.medication.GetMedicationsUseCase
 import com.moon.pharm.domain.usecase.medication.GetMonthlyIntakeRecordsUseCase
@@ -26,6 +27,7 @@ import javax.inject.Inject
 class MedicationHistoryViewModel @Inject constructor(
     private val getMonthlyIntakeRecordsUseCase: GetMonthlyIntakeRecordsUseCase,
     private val getMedicationsUseCase: GetMedicationsUseCase,
+    private val medicationRepository: MedicationRepository,
     private val toggleIntakeCheckUseCase: ToggleIntakeCheckUseCase,
     private val authRepository: AuthRepository
 ) : ViewModel() {
@@ -143,6 +145,19 @@ class MedicationHistoryViewModel @Inject constructor(
                 record = record,
                 isTaken = isNowTaken
             ).collectLatest { }
+        }
+    }
+
+    fun deleteMedication(medicationId: String) {
+        viewModelScope.launch {
+            medicationRepository.deleteMedication(medicationId).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Failure -> {
+                        result.exception.printStackTrace()
+                    }
+                    else -> { }
+                }
+            }
         }
     }
 

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationUiEvent.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationUiEvent.kt
@@ -22,6 +22,7 @@ sealed interface MedicationUiEvent {
     // 2. 주요 비즈니스 로직 (Business Logic)
     object SaveAllMedications : MedicationUiEvent
     data class ToggleTaken(val medicationId: String, val scheduleId: String) : MedicationUiEvent
+    data class DeleteMedication(val medicationId: String) : MedicationUiEvent
 
     // 3. UI 상태 및 시스템 이벤트 (UI State & System)
     data class SelectTab(val tab: MedicationPrimaryTab) : MedicationUiEvent

--- a/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationViewModel.kt
+++ b/features/profile/src/main/java/com/moon/pharm/profile/medication/viewmodel/MedicationViewModel.kt
@@ -202,6 +202,7 @@ class MedicationViewModel @Inject constructor(
 
             // 2. 주요 비즈니스 로직
             MedicationUiEvent.SaveAllMedications -> saveAllMedications()
+            is MedicationUiEvent.DeleteMedication -> deleteMedication(event.medicationId)
             is MedicationUiEvent.ToggleTaken -> toggleMedicationTaken(
                 medicationId = event.medicationId,
                 scheduleId = event.scheduleId
@@ -398,6 +399,19 @@ class MedicationViewModel @Inject constructor(
             ).collectLatest { result ->
                 if (result is DataResourceResult.Failure) {
                     result.exception.printStackTrace()
+                }
+            }
+        }
+    }
+
+    private fun deleteMedication(medicationId: String) {
+        viewModelScope.launch {
+            medicationRepository.deleteMedication(medicationId).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Failure -> {
+                        result.exception.printStackTrace()
+                    }
+                    else -> { }
                 }
             }
         }

--- a/features/profile/src/main/res/values/strings.xml
+++ b/features/profile/src/main/res/values/strings.xml
@@ -106,4 +106,14 @@
 
     <string name="medication_time_label">%1$s 복용</string>
     <string name="medication_progress_today">오늘 복용 %1$d/%2$d회 완료</string>
+
+    <string name="medication_history_title">나의 복약 기록</string>
+    <string name="medication_history_detail_title">%1$s 복약 상세</string>
+    <string name="medication_history_empty">복약 기록이 없습니다.</string>
+
+    <string name="medication_delete">삭제하기</string>
+    <string name="medication_delete_dialog_title">복약 삭제</string>
+    <string name="medication_delete_dialog_content">이 약을 삭제하시겠습니까?\n 묶음 설정된 모든 시간대의 스케줄이 함께 삭제됩니다.</string>
+    <string name="medication_option_menu_desc">옵션 메뉴</string>
+    <string name="medication_delete_desc">삭제</string>
 </resources>


### PR DESCRIPTION
- 복약 홈(`MedicationItemCard`) 및 기록(`HistoryRecordItem`) 화면에 더보기 옵션(점 3개) 및 삭제 메뉴 추가
- 특정 시간대의 약을 삭제할 때 `medicationId`를 기준으로 삭제 로직을 호출하여, 해당 약으로 묶인 모든 시간대(스케줄)의 복약 정보가 함께 일괄 삭제되도록 구현
- UI 내 하드코딩된 문자열(삭제 메뉴, 빈 화면 안내 등)을 `strings.xml` 리소스로 추출

Close #10 