### PR TITLE
chore(domain): 불필요한 AndroidManifest.xml 삭제

### DIFF
--- a/domain/src/main/AndroidManifest.xml
+++ b/domain/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-</manifest>


### PR DESCRIPTION
## 목적
- 모듈 생성 초기 템플릿의 잔재로 남아있던 빈 매니페스트 파일을 제거
- 순수 자바/코틀린 라이브러리(java-library)로 구성된 domain 모듈임을 명확히 함

## 작업 내용
- domain 모듈 내에 남아있던 `src/main/AndroidManifest.xml` 빈 파일 삭제

